### PR TITLE
Update ReportGenerator.Core to 5.1.4

### DIFF
--- a/src/CoveragePublisher/CoveragePublisher.csproj
+++ b/src/CoveragePublisher/CoveragePublisher.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="CommandLineParser" Version="2.5.0" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.153.0-preview" />
     <PackageReference Include="Microsoft.TeamFoundation.PublishTestResults" Version="16.153.0-preview" />
-    <PackageReference Include="ReportGenerator.Core" Version="4.4.6" />
+    <PackageReference Include="ReportGenerator.Core" Version="5.1.4" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Use ReportGenerator.Core v5.1.4 version to fix [issue 43](https://github.com/microsoft/azure-pipelines-coveragepublisher/issues/43)