### PR TITLE
Removing the dotnet dependency

### DIFF
--- a/src/CoveragePublisher.Console/CoveragePublisher.Console.csproj
+++ b/src/CoveragePublisher.Console/CoveragePublisher.Console.csproj
@@ -2,7 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
+     <TargetFramework>net6.0</TargetFramework>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <PublishTrimmed>true</PublishTrimmed>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 


### PR DESCRIPTION
By this we will removing the step of adding the required .net core sdk task in the azure pipeline. 