### PR TITLE
Fixes the build failure due to .NET version change

### DIFF
--- a/src/CoveragePublisher.Console/CoveragePublisher.Console.csproj
+++ b/src/CoveragePublisher.Console/CoveragePublisher.Console.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-     <TargetFramework>net7.0</TargetFramework>
+     <TargetFramework>net6.0</TargetFramework>
     <PublishSingleFile>true</PublishSingleFile>
-    <SelfContained>true</SelfContained>
+    <SelfContained>false</SelfContained>
     <PublishTrimmed>true</PublishTrimmed>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>

--- a/src/CoveragePublisher.Console/CoveragePublisher.Console.csproj
+++ b/src/CoveragePublisher.Console/CoveragePublisher.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-     <TargetFramework>net6.0</TargetFramework>
+     <TargetFramework>net7.0</TargetFramework>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <PublishTrimmed>true</PublishTrimmed>


### PR DESCRIPTION
**Bug in detail:** https://github.com/microsoft/azure-pipelines-coveragepublisher/issues/53

```error NETSDK1031: It is not supported to build or publish a self-contained application without specifying a RuntimeIdentifier. You must either specify a RuntimeIdentifier or set SelfContained to false. [/Users/dtsapple/CoveragePublisher/azure-pipelines-coveragepublisher/src/CoveragePublisher.Console/CoveragePublisher.Console.csproj]```

**Explain fix**
Setting SelfContained to False, removes the need of setting the RuntimeIdentifier which is very personal to the user and can't be hardcoded.

**Repro steps:**
Install .NET6 
dotnet build 

Or install on .NET 3.1  (like needed for before `netcoreapp3.1;net462`)

**Why it didn't get caught on pipeline**
Because the check ran on commit https://github.com/microsoft/azure-pipelines-coveragepublisher/commit/68874da7beca059f794f23134eacae60ecea0626

Installs **.NET7**  but as a user, seeing targetFramework **.net6**, I updated to 6 (from 3.1) and still faced the build failure. 
https://github.com/microsoft/azure-pipelines-coveragepublisher/actions/runs/4685895850/jobs/8303415148
<img width="961" alt="image" src="https://user-images.githubusercontent.com/6470509/232028847-5d34d5f6-e06c-4ae4-b89d-e498eb52b4f8.png">



