### PR TITLE
Adding ability to upload native coverage files like .coverage, .covx , .covb and .cjson to ADO. 

### DIFF
--- a/src/CoveragePublisher.Tests/CoverageProcessorTests.cs
+++ b/src/CoveragePublisher.Tests/CoverageProcessorTests.cs
@@ -43,7 +43,7 @@ namespace CoveragePublisher.Tests
 
             _mockPublisher.Setup(x => x.IsFileCoverageJsonSupported()).Returns(false);
             _mockParser.Setup(x => x.GetCoverageSummary()).Returns(summary);
-            
+
             processor.ParseAndPublishCoverage(_config, token, _mockParser.Object).Wait();
 
             _mockPublisher.Verify(x => x.PublishCoverageSummary(
@@ -95,11 +95,13 @@ namespace CoveragePublisher.Tests
         }
 
         [TestMethod]
+
         public void PublishNativeCoverageFiles()
         {
             // Arrange
             var logger = new TestLogger();
             TraceLogger.Initialize(logger);
+            var summary = new CoverageSummary();
 
             var token = new CancellationToken();
             var processor = new CoverageProcessor(_mockPublisher.Object, _mockTelemetryDataCollector.Object);
@@ -114,7 +116,7 @@ namespace CoveragePublisher.Tests
             _mockParser.Setup(x => x.GetFileCoverageInfos()).Returns(coverage);
 
             _mockPublisher.Verify(x => x.PublishNativeCoverageFiles(
-                It.Is<List<string>>( a=> a == nativeCoverageFiles),
+                It.Is<List<string>>(a => a == nativeCoverageFiles),
                 It.Is<CancellationToken>(b => b == token)), Times.Never);
 
             // Act
@@ -123,8 +125,6 @@ namespace CoveragePublisher.Tests
             // Assert
             Assert.IsTrue(logger.Log.Contains("Publishing native coverage files is supported."));
         }
-      
-        [TestMethod]
         public void ParseAndPublishCoverageWillPublishFileAndCodeCoverageSummary()
         {
             var token = new CancellationToken();
@@ -138,10 +138,10 @@ namespace CoveragePublisher.Tests
 
             _mockPublisher.Setup(x => x.IsFileCoverageJsonSupported()).Returns(false);
             _mockParser.Setup(x => x.GetCoverageSummary()).Returns(summary);
-            
+
             _mockPublisher.Setup(x => x.IsFileCoverageJsonSupported()).Returns(true);
             _mockParser.Setup(x => x.GetFileCoverageInfos()).Returns(coverage);
-            
+
             processor.ParseAndPublishCoverage(_config, token, _mockParser.Object).Wait();
 
             _mockPublisher.Verify(x => x.PublishCoverageSummary(
@@ -152,7 +152,7 @@ namespace CoveragePublisher.Tests
                 It.Is<List<FileCoverageInfo>>(a => a == coverage),
                 It.Is<CancellationToken>(b => b == token)));
         }
-      
+
         [TestMethod]
         public void WillNotPublishCoverageSummaryIfDataIsNotNull()
         {
@@ -164,14 +164,14 @@ namespace CoveragePublisher.Tests
 
             _mockPublisher.Setup(x => x.IsFileCoverageJsonSupported()).Returns(false);
             _mockParser.Setup(x => x.GetCoverageSummary()).Returns(summary);
-            
+
             processor.ParseAndPublishCoverage(_config, token, _mockParser.Object).Wait();
 
             _mockPublisher.Verify(x => x.PublishCoverageSummary(
                 It.Is<CoverageSummary>(a => a == summary),
                 It.Is<CancellationToken>(b => b == token)));
 
-           Assert.IsNotNull(summary.CodeCoverageData);
+            Assert.IsNotNull(summary.CodeCoverageData);
         }
     }
 }

--- a/src/CoveragePublisher.Tests/Publishers/AzurePipelines/AzurePipelinesPublisherTests.cs
+++ b/src/CoveragePublisher.Tests/Publishers/AzurePipelines/AzurePipelinesPublisherTests.cs
@@ -40,6 +40,63 @@ namespace CoveragePublisher.Tests
         }
 
         [TestMethod]
+        public void WillPublishNativeCoverageFilesToLogStore()
+        {
+            // Arrange
+            var token = new CancellationToken();
+            var publisher = new AzurePipelinesPublisher(_context, _mockClientFactory.Object, _mockFFHelper.Object, _mockHtmlPublisher.Object, _mockLogStoreHelper.Object, true);
+            var mockClient = new Mock<TestResultsHttpClient>(new Uri("http://localhost"), new VssCredentials());
+
+            _mockClientFactory.Setup(x => x.GetClient<TestResultsHttpClient>()).Returns(mockClient.Object);
+            
+            // Feature flags
+            _mockFFHelper.Setup(x => x.GetFeatureFlagState(
+                It.Is<string>(a => a == Constants.FeatureFlags.EnablePublishToTcmServiceDirectlyFromTaskFF),
+                It.Is<bool>(b => b == false))).Returns(true);
+            _mockFFHelper.Setup(x => x.GetFeatureFlagState(
+                It.Is<string>(a => a == Constants.FeatureFlags.UploadNativeCoverageFilesToLogStore),
+                It.Is<bool>(b => b == false))).Returns(true);
+            
+            _mockLogStoreHelper.Setup(x => x.UploadTestBuildLogAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<int>(),
+                It.IsAny<TestLogType>(),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.IsAny<string>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+                .Callback<Guid, int, TestLogType, string, Dictionary<string, string>, string, bool, CancellationToken>(
+                    (a, b, c, d, e, f, g, h) =>
+                    {
+                        
+                    })
+                .Returns(Task.FromResult<TestLogStatus>(null));
+
+            var nativeCoverageFiles = new List<string>()
+            {
+                "C:\\a\\sample.coverage",
+                "C:\\a\\sample.covx",
+                "C:\\a\\sample.covb",
+                "C:\\a\\sample.cjson"
+            };
+
+            // Act
+            publisher.PublishNativeCoverageFiles(nativeCoverageFiles, token).Wait();
+
+            // Assert
+            _mockLogStoreHelper.Verify(x => x.UploadTestBuildLogAsync(
+                It.Is<Guid>(a => a == _context.ProjectId),
+                It.Is<int>(b => b == _context.BuildId),
+                It.Is<TestLogType>(c => c == TestLogType.Intermediate),
+                It.IsAny<string>(),
+                It.IsAny<Dictionary<string, string>>(),
+                It.Is<string>(f => f == null),
+                It.Is<bool>(g => g == true),
+                It.Is<CancellationToken>(e => e == token)));
+        }
+
+		[TestMethod]
         public void WillPublishHtmlReport()
         {
             var publisher = new AzurePipelinesPublisher(_context, _mockClientFactory.Object, _mockFFHelper.Object, _mockHtmlPublisher.Object, _mockLogStoreHelper.Object, true);

--- a/src/CoveragePublisher/CoverageProcessor.cs
+++ b/src/CoveragePublisher/CoverageProcessor.cs
@@ -54,6 +54,17 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
                         }
                         else
                         {
+                            // Upload native coverage files to TCM
+                            var uploadNativeCoverageFilesToLogStore = _publisher.IsUploadNativeFilesToTCMSupported();
+                            _telemetry.AddOrUpdate("uploadNativeCoverageFilesToLogStore", uploadNativeCoverageFilesToLogStore.ToString());
+
+                            if (uploadNativeCoverageFilesToLogStore)
+                            {
+                                TraceLogger.Debug("Publishing native coverage files is supported.");
+
+                                await _publisher.PublishNativeCoverageFiles(config.CoverageFiles, token);
+                            }
+
                             using (new SimpleTimer("CoverageProcesser", "PublishFileCoverage", _telemetry))
                             {
                                 await _publisher.PublishFileCoverage(fileCoverage, token);

--- a/src/CoveragePublisher/CoverageProcessor.cs
+++ b/src/CoveragePublisher/CoverageProcessor.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
                     });
 
                     var supportsFileCoverageJson = _publisher.IsFileCoverageJsonSupported();
-                    var fileCoverage = parser.GetFileCoverageInfos();
                     var uploadNativeCoverageFilesToLogStore = _publisher.IsUploadNativeFilesToTCMSupported();
                     _telemetry.AddOrUpdate("uploadNativeCoverageFilesToLogStore", uploadNativeCoverageFilesToLogStore.ToString());
 
@@ -52,14 +51,11 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
                         TraceLogger.Debug("Publishing native coverage files is supported.");
 
                         await _publisher.PublishNativeCoverageFiles(config.CoverageFiles, token);
-
-                        using (new SimpleTimer("CoverageProcesser", "PublishFileCoverage", _telemetry))
-                        {
-                            await _publisher.PublishFileCoverage(fileCoverage, token);
-                        }
                     }
                     if (supportsFileCoverageJson)
                     {
+                        var fileCoverage = parser.GetFileCoverageInfos();
+
                         var summary = parser.GetCoverageSummary();
 
                         bool IsCodeCoverageData = (summary.CodeCoverageData != null);
@@ -85,6 +81,13 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
                         if (fileCoverage.Count == 0)
                         {
                             TraceLogger.Warning(Resources.NoCoverageFilesGenerated);
+                        }
+                        else
+                        {
+                            using (new SimpleTimer("CoverageProcesser", "PublishFileCoverage", _telemetry))
+                            {
+                                await _publisher.PublishFileCoverage(fileCoverage, token);
+                            }
                         }
                     }
                     else

--- a/src/CoveragePublisher/Model/Publishers/ICoveragePublisher.cs
+++ b/src/CoveragePublisher/Model/Publishers/ICoveragePublisher.cs
@@ -20,6 +20,14 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Model
         Task PublishFileCoverage(IList<FileCoverageInfo> coverageInfos, CancellationToken cancellationToken);
 
         /// <summary>
+        /// Publish all native coverage files to log store
+        /// </summary>
+        /// <param name="nativeCoverageFiles">List of native coverage files</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+        /// <returns></returns>
+        Task PublishNativeCoverageFiles(IList<string> nativeCoverageFiles, CancellationToken cancellationToken);
+
+        /// <summary>
         /// Publish coverage summary.
         /// </summary>
         /// <param name="coverageSummary">CoverageSummary object.</param>
@@ -37,5 +45,11 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Model
         /// Gets weather publisher supports publishing <see cref="FileCoverageInfo"/> format.
         /// </summary>
         bool IsFileCoverageJsonSupported();
+
+        /// <summary>
+        /// Gets weather we can upload native file to tcm logstore.
+        /// </summary>
+        /// <returns></returns>
+        bool IsUploadNativeFilesToTCMSupported();
     }
 }

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/AzurePipelinesPublisher.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/AzurePipelinesPublisher.cs
@@ -165,6 +165,66 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
             await _htmlReportPublisher.PublishHTMLReportAsync(reportDirectory, token);
         }
 
+        public bool IsUploadNativeFilesToTCMSupported()
+        {
+            return _featureFlagHelper.GetFeatureFlagState(Constants.FeatureFlags.UploadNativeCoverageFilesToLogStore, false);
+        }
+
+        public async Task PublishNativeCoverageFiles(IList<string> nativeCoverageFiles, CancellationToken cancellationToken)
+        {
+            if (nativeCoverageFiles == null || nativeCoverageFiles.Count == 0)
+            {
+                return;
+            }
+
+            TraceLogger.Info(Resources.PublishingFileCoverage);
+
+            try
+            {
+                _executionContext.TelemetryDataCollector.AddOrUpdate("TotalNativeCoverageFilesCount", nativeCoverageFiles.Count);
+
+                Dictionary<string, string> metaData = new Dictionary<string, string>();
+                using (new SimpleTimer("AzurePipelinesPublisher", "UploadNativeCoverageFiles", _executionContext.TelemetryDataCollector))
+                {
+                    int uploadedFileCount = 0;
+                    foreach (string nativeCoverageFile in nativeCoverageFiles)
+                    {
+                        if (!(nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageBufferFileExtension) ||
+                            nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageFileExtension) ||
+                            nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageBFileExtension) ||
+                            nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageJsonFileExtension) ||
+                            nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageXFileExtension)))
+                        {
+                            continue;
+                        }
+
+                        TestLogType testLogType = GetTestLogType(nativeCoverageFile);
+                        await _logStoreHelper.UploadTestBuildLogAsync(_executionContext.ProjectId, _executionContext.BuildId, testLogType, nativeCoverageFile, metaData, null, true, cancellationToken);
+                        uploadedFileCount++;
+                    }
+
+                    _executionContext.TelemetryDataCollector.AddOrUpdate("UploadedNativeCoverageFilesCount", uploadedFileCount);
+                }
+            }
+            catch (Exception ex)
+            {
+                TraceLogger.Error(string.Format(Resources.FailedToUploadNativeCoverageFiles, ex));
+            }
+        }
+
+        private TestLogType GetTestLogType(string nativeCoverageFile) 
+        { 
+            TestLogType logType = TestLogType.Intermediate;
+        
+            if (nativeCoverageFile != null & 
+                nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageFileExtension))
+            {
+                logType = TestLogType.CodeCoverage;
+            }
+
+            return logType;
+        }
+        
         private VssConnection GetVssConnection()
         {
             var proxy = VssProxyHelper.GetProxy();
@@ -172,7 +232,6 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
             {
                 VssHttpMessageHandler.DefaultWebProxy = proxy;
             }
-
             var connectionSettings = VssSettingsConfiguration.GetSettings();
             return new VssConnection(new Uri(_executionContext.CollectionUri), new VssBasicCredential("", _executionContext.AccessToken), connectionSettings);
         }

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/AzurePipelinesPublisher.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/AzurePipelinesPublisher.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
 
         public bool IsUploadNativeFilesToTCMSupported()
         {
-            return _featureFlagHelper.GetFeatureFlagState(Constants.FeatureFlags.UploadNativeCoverageFilesToLogStore, false);
+            return _featureFlagHelper.GetFeatureFlagState(Constants.FeatureFlags.UploadNativeCoverageFilesToLogStore, true);
         }
 
         public async Task PublishNativeCoverageFiles(IList<string> nativeCoverageFiles, CancellationToken cancellationToken)

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Constants.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Constants.cs
@@ -38,7 +38,16 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
         internal static class FeatureFlags
         {
             public const string EnablePublishToTcmServiceDirectlyFromTaskFF = "TestManagement.Server.EnablePublishToTcmServiceDirectlyFromTask";
+            public const string UploadNativeCoverageFilesToLogStore = "TestManagement.Server.UploadNativeCoverageFilesToLogStore";
             public const string TestLogStoreOnTCMService = "TestManagement.Server.TestLogStoreOnTCMService";
         }
-    }
+        internal static class CoverageConstants
+        {
+            public const string CoverageFileExtension = ".coverage";
+            public const string CoverageBufferFileExtension = ".coveragebuffer";
+            public const string CoverageXFileExtension = ".covx";
+            public const string CoverageBFileExtension = ".covb";
+            public const string CoverageJsonFileExtension = ".cjson";
+        }
+	}
 }

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Resources.Designer.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Resources.Designer.cs
@@ -132,11 +132,22 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
                 return ResourceManager.GetString("FailedToUploadFileCoverage", resourceCulture);
             }
         }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Unable to copy file to server StatusCode={0}: {1}. Source file path: {2}. Target server path: {3}..
-        /// </summary>
-        internal static string FileContainerUploadFailed {
+
+		/// <summary>
+		///   Looks up a localized string similar to Failed to upload file coverage data. Exception: {1}.
+		/// </summary>
+		internal static string FailedToUploadNativeCoverageFiles
+		{
+			get
+			{
+				return ResourceManager.GetString("FailedToUploadNativeCoverageFiles", resourceCulture);
+			}
+		}
+
+		/// <summary>
+		///   Looks up a localized string similar to Unable to copy file to server StatusCode={0}: {1}. Source file path: {2}. Target server path: {3}..
+		/// </summary>
+		internal static string FileContainerUploadFailed {
             get {
                 return ResourceManager.GetString("FileContainerUploadFailed", resourceCulture);
             }

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Resources.resx
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Resources.resx
@@ -130,7 +130,7 @@
     <value>Error occurred while publishing code coverage files. Error: {0}.</value>
   </data>
   <data name="FailedToGetFeatureFlag" xml:space="preserve">
-    <value>Failed to get FF {0} Value. By default, publishing data to TCM.</value>
+    <value>Failed to get FF {0} Value.</value>
   </data>
   <data name="FailedtoUploadCoverageSummary" xml:space="preserve">
     <value>Failed to upload coverage summary. Exception: {0}.</value>
@@ -200,5 +200,8 @@
   </data>
   <data name="PublishingFileCoverage" xml:space="preserve">
     <value>Publishing file coverage data.</value>
+  </data>
+  <data name="FailedToUploadNativeCoverageFiles" xml:space="preserve">
+    <value>Failed to upload native coverage files. Exception: {1}</value>
   </data>
 </root>


### PR DESCRIPTION
**Summary**

1. Adding capabilities to upload native coverage files like .coverage, .covx, .covb, .cjson to tcm log store.
2. This would allow the files to be processed for merging as part of build completion event to generate the final view.

**Local Testing** -

**Setup** 
The edited task is run with a variety of input files, including .coverage, .covx etc. 
Checked that the merged file was being uploaded in logstore

1. **.coverage** 

![coverage](https://github.com/microsoft/azure-pipelines-coveragepublisher/assets/34476976/3923d03a-6be1-4be6-8f2a-8119a086325c)

2.  **.covx**

![covx](https://github.com/microsoft/azure-pipelines-coveragepublisher/assets/34476976/3fcfe36a-5b0c-4b39-a041-6c2f04c7cb47)

3. **.covb**

![covb](https://github.com/microsoft/azure-pipelines-coveragepublisher/assets/34476976/be65e22e-5406-43e3-b21b-a9a4a2e7c904)

4. **cjson**

![cjson](https://github.com/microsoft/azure-pipelines-coveragepublisher/assets/34476976/d44de35a-e309-41fd-8722-c811dd3e89be)


 