### PR TITLE
Fixing the BQC compat issue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,16 +40,17 @@ steps:
           }
       }
 
-- task: NuGetToolInstaller@0
+- task: NuGetToolInstaller@1
 
 - task: NuGetCommand@2
   inputs:
     restoreSolution: '$(solution)'
 
 - task: UseDotNet@2
+  displayName: 'Use .NET Core sdk 7.0.x'
   inputs:
-    packageType: 'sdk'
-    version: '2.1.x'
+    version: 7.0.x
+
 
 - task: DotNetCoreCLI@2
   inputs:
@@ -57,7 +58,7 @@ steps:
     projects: '**/*.sln'
     feedsToUse: 'select'
     versioningScheme: 'off'
-    arguments: '-c release'
+    arguments: '-c Release'
 
 - task: DotNetCoreCLI@2
   inputs:
@@ -68,16 +69,51 @@ steps:
     feedsToUse: 'select'
     versioningScheme: 'off'
 
-- task: BuildQualityChecks@5
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet publish'
   inputs:
-    checkCoverage: true
-    coverageFailOption: 'fixed'
-    coverageType: 'lines'
-    coverageThreshold: '84'
+    command: publish
+    publishWebProjects: false
+    projects: '**/CoveragePublisher.Console.csproj'
+    arguments: '--no-build -c Release -f net7.0 -r win-x64'
+    zipAfterPublish: false
+    modifyOutputPath: false
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet publish for linux'
+  inputs:
+    command: publish
+    publishWebProjects: false
+    projects: '**/CoveragePublisher.Console.csproj'
+    arguments: '-c Release -f net7.0 -r linux-x64'
+    zipAfterPublish: false
+    modifyOutputPath: false
+
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet publish for macos'
+  inputs:
+    command: publish
+    publishWebProjects: false
+    projects: '**/CoveragePublisher.Console.csproj'
+    arguments: '-c Release -f net7.0 -r osx-x64'
+    zipAfterPublish: false
+    modifyOutputPath: false
 
 - task: CopyFiles@2
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)/src/CoveragePublisher.Console/bin/release/netcoreapp2.1'
+    SourceFolder: '$(Build.SourcesDirectory)/src/CoveragePublisher.Console/bin/Release/net7.0/win-x64/publish/'
+    Contents: '**'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)'
+
+- task: CopyFiles@2
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)/src/CoveragePublisher.Console/bin/Release/net7.0/linux-x64/publish/'
+    Contents: '**'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)/linux-x64'
+
+- task: CopyFiles@2
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)/src/CoveragePublisher.Console/bin/Release/net7.0/win-x64'
     Contents: |
       **/*.dll
       CoveragePublisher.Console.runtimeconfig.json
@@ -85,14 +121,11 @@ steps:
 
 - task: CopyFiles@2
   inputs:
-    SourceFolder: '$(Build.SourcesDirectory)/src/CoveragePublisher.Console/bin/release/net461'
-    Contents: |
-      CoveragePublisher.Console.exe
-      CoveragePublisher.Console.exe.config
+    SourceFolder: '$(Build.SourcesDirectory)/src/CoveragePublisher.Console/bin/Release/net7.0/osx-x64/publish/'
+    Contents: '**'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)/osx-x64'
 
-    TargetFolder: '$(Build.ArtifactStagingDirectory)'
-    flattenFolders: true
-
+    
 - task: PowerShell@2
   inputs:
     targetType: 'inline'

--- a/nuget.config
+++ b/nuget.config
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <packageSources>
-        <add key="Nuget" value="https://api.nuget.org/v3/index.json" />
-    </packageSources>
     <config>
       <add key="globalPackagesFolder" value="packages" />
     </config>

--- a/src/CoveragePublisher.Console/CoveragePublisher.Console.csproj
+++ b/src/CoveragePublisher.Console/CoveragePublisher.Console.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-     <TargetFramework>net7.0</TargetFramework>
-    <PublishSingleFile>true</PublishSingleFile>
+     <TargetFrameworks>net7.0;net462</TargetFrameworks>
+    <PublishSingleFile>false</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <PublishTrimmed>true</PublishTrimmed>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/CoveragePublisher.Tests/CoverageProcessorTests.cs
+++ b/src/CoveragePublisher.Tests/CoverageProcessorTests.cs
@@ -110,5 +110,34 @@ namespace CoveragePublisher.Tests
 
             Assert.IsTrue(logger.Log.Contains("error: An error occured while publishing coverage files. System.Exception: error"));
         }
+
+        [TestMethod]
+        public void ParseAndPublishCoverageWillPublishFileAndCodeCoverageSummary()
+        {
+            var token = new CancellationToken();
+            var processor = new CoverageProcessor(_mockPublisher.Object, _mockTelemetryDataCollector.Object);
+            var coverage = new List<FileCoverageInfo>();
+            coverage.Add(new FileCoverageInfo());
+
+            var summary = new CoverageSummary();
+
+            summary.AddCoverageStatistics("", 3, 3, CoverageSummary.Priority.Class);
+
+            _mockPublisher.Setup(x => x.IsFileCoverageJsonSupported()).Returns(false);
+            _mockParser.Setup(x => x.GetCoverageSummary()).Returns(summary);
+            
+            _mockPublisher.Setup(x => x.IsFileCoverageJsonSupported()).Returns(true);
+            _mockParser.Setup(x => x.GetFileCoverageInfos()).Returns(coverage);
+            
+            processor.ParseAndPublishCoverage(_config, token, _mockParser.Object).Wait();
+
+            _mockPublisher.Verify(x => x.PublishCoverageSummary(
+                It.Is<CoverageSummary>(a => a == summary),
+                It.Is<CancellationToken>(b => b == token)));
+
+            _mockPublisher.Verify(x => x.PublishFileCoverage(
+                It.Is<List<FileCoverageInfo>>(a => a == coverage),
+                It.Is<CancellationToken>(b => b == token)));
+        }
     }
 }

--- a/src/CoveragePublisher.Tests/CoverageProcessorTests.cs
+++ b/src/CoveragePublisher.Tests/CoverageProcessorTests.cs
@@ -123,7 +123,7 @@ namespace CoveragePublisher.Tests
         }
 
         [TestMethod]
-        public void WillNotPublishCoverageSummaryIfDataIsNull()
+        public void WillNotPublishCoverageSummaryIfDataIsNotNull()
         {
             var token = new CancellationToken();
             var processor = new CoverageProcessor(_mockPublisher.Object, _mockTelemetryDataCollector.Object);

--- a/src/CoveragePublisher/CoverageProcessor.cs
+++ b/src/CoveragePublisher/CoverageProcessor.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
                     }
                     else
                     {
-                        TraceLogger.Debug("Publishing file json coverage is not supported.");
+                        TraceLogger.Debug("Publishing file cjson coverage is not supported.");
                         var summary = parser.GetCoverageSummary();
 
                         if (summary == null || summary.CodeCoverageData.CoverageStats.Count == 0)

--- a/src/CoveragePublisher/CoverageProcessor.cs
+++ b/src/CoveragePublisher/CoverageProcessor.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
                     }
                     else
                     {
-                        TraceLogger.Debug("Publishing file cjson coverage is not supported.");
+                        TraceLogger.Debug("Publishing file json coverage is not supported.");
                         var summary = parser.GetCoverageSummary();
 
                         if (summary == null || summary.CodeCoverageData.CoverageStats.Count == 0)

--- a/src/CoveragePublisher/CoverageProcessor.cs
+++ b/src/CoveragePublisher/CoverageProcessor.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
             {
                 try
                 {
-                    TraceLogger.Debug("Publishing file json coverage supported");
+                    TraceLogger.Debug("Publishing file json coverage supported.");
 
                     _telemetry.AddOrUpdate("PublisherConfig", () =>
                     {

--- a/src/CoveragePublisher/CoverageProcessor.cs
+++ b/src/CoveragePublisher/CoverageProcessor.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
             {
                 try
                 {
+                    TraceLogger.Debug("Publishing file json coverage supported");
+
                     _telemetry.AddOrUpdate("PublisherConfig", () =>
                     {
                         return "{" +
@@ -47,11 +49,15 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
 
                         var summary = parser.GetCoverageSummary();
 
+                        bool IsCodeCoverageData = (summary.CodeCoverageData != null);
+
+                        bool IsCoverageStats = (summary.CodeCoverageData.CoverageStats != null);
+
                         _telemetry.AddOrUpdate("UniqueFilesCovered", fileCoverage.Count);
 
                         TraceLogger.Debug("Publishing code coverage summary supported");
 
-                        if (summary == null || summary.CodeCoverageData.CoverageStats.Count == 0)
+                        if (summary == null || (IsCodeCoverageData  && IsCoverageStats  && summary.CodeCoverageData.CoverageStats.Count == 0)) 
                         {
                             TraceLogger.Warning(Resources.NoSummaryStatisticsGenerated);
                         }
@@ -63,7 +69,6 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
                             }
                         }
 
-                        TraceLogger.Debug("Publishing file json coverage supported");
                         if (fileCoverage.Count == 0)
                         {
                             TraceLogger.Warning(Resources.NoCoverageFilesGenerated);

--- a/src/CoveragePublisher/CoveragePublisher.csproj
+++ b/src/CoveragePublisher/CoveragePublisher.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>library</OutputType>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net462</TargetFrameworks>
     <RootNamespace>Microsoft.Azure.Pipelines.CoveragePublisher</RootNamespace>
     <AssemblyName>Microsoft.Azure.Pipelines.CoveragePublisher</AssemblyName>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/CoveragePublisher/CoveragePublisher.csproj
+++ b/src/CoveragePublisher/CoveragePublisher.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="Microsoft.TeamFoundation.PublishTestResults" Version="16.199.0-preview" />
     <PackageReference Include="ReportGenerator.Core" Version="5.1.19" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/AzurePipelinesPublisher.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/AzurePipelinesPublisher.cs
@@ -112,6 +112,9 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
                     TraceLogger.Error(string.Format(Resources.FailedtoUploadCoverageSummary, ex.ToString()));
                 }
             }
+            else{
+                TraceLogger.Warning(Resources.FailedtoUploadCoverageSummary);
+            }
         }
 
         public async Task PublishFileCoverage(IList<FileCoverageInfo> coverageInfos, CancellationToken cancellationToken)


### PR DESCRIPTION
**PR Description :**

Currently when the PCCRV2 task is used with the BQC task, the BQC task fails. It works fine with the PCCRV1 task. This is mainly because we dont have an UpdateCodeCoverageSummary method implemented when we use the PCCRV2 task . It was only using the PublishFileCoverage method which used to used perform the functionality of uploading the merged cjson files to the Logstore. But it did not used to update the code coverage summary , as a result the Code coverage summary would be null and hence that would fail the BQC task. 

This is BQC task uses the GetCodeCoverageSummary method , so if the coverage summary is null, then that method in BQC would fail. Hence to fix this issue, we are calling the PublishCoverageSummary method as well so that it performs the update opertaiton. The PublishCoverageSummary is already implemented in this repo and it takes care of updating the coverage summary.

**Testing:**

**All test cases passed:**

![image](https://github.com/microsoft/azure-pipelines-coveragepublisher/assets/110326599/01f7193a-8ae7-4881-a0f9-84b0f960c738)


**Before: Build fails as the BQC task fails**

![image](https://github.com/microsoft/azure-pipelines-coveragepublisher/assets/110326599/f0218844-2a12-49ac-b149-b66b9899a0dd)

**After : Build passed as the BQC task passed:**

![image](https://github.com/microsoft/azure-pipelines-coveragepublisher/assets/110326599/ac3211b8-7f1e-47eb-8959-3f865d9b8ed5)

**Logs of BQC:** 

![image](https://github.com/microsoft/azure-pipelines-coveragepublisher/assets/110326599/9516fc52-ac01-436a-9cf5-531df57bae8e)

