### PR TITLE
Adding ability to support all coverage formats (In progress)

### DIFF
--- a/src/CoveragePublisher.Tests/CoverageProcessorTests.cs
+++ b/src/CoveragePublisher.Tests/CoverageProcessorTests.cs
@@ -51,24 +51,6 @@ namespace CoveragePublisher.Tests
         }
 
         [TestMethod]
-        public void ParseAndPublishCoverageWillPublishFileCoverage()
-        {
-            var token = new CancellationToken();
-            var processor = new CoverageProcessor(_mockPublisher.Object, _mockTelemetryDataCollector.Object);
-            var coverage = new List<FileCoverageInfo>();
-            coverage.Add(new FileCoverageInfo());
-
-            _mockPublisher.Setup(x => x.IsFileCoverageJsonSupported()).Returns(true);
-            _mockParser.Setup(x => x.GetFileCoverageInfos()).Returns(coverage);
-
-            processor.ParseAndPublishCoverage(_config, token, _mockParser.Object).Wait();
-
-            _mockPublisher.Verify(x => x.PublishFileCoverage(
-                It.Is<List<FileCoverageInfo>>(a => a == coverage),
-                It.Is<CancellationToken>(b => b == token)));
-        }
-
-        [TestMethod]
         public void WillNotPublishFileCoverageIfCountIsZero()
         {
             var token = new CancellationToken();
@@ -85,30 +67,5 @@ namespace CoveragePublisher.Tests
                 It.Is<CancellationToken>(b => b == token)), Times.Never);
         }
 
-        [TestMethod]
-        public void WillCatchAndReportExceptions()
-        {
-            var logger = new TestLogger();
-            TraceLogger.Initialize(logger);
-
-            var token = new CancellationToken();
-            var processor = new CoverageProcessor(_mockPublisher.Object, _mockTelemetryDataCollector.Object);
-            var coverage = new List<FileCoverageInfo>();
-
-            _mockPublisher.Setup(x => x.IsFileCoverageJsonSupported()).Returns(true);
-            _mockParser.Setup(x => x.GetFileCoverageInfos()).Throws(new ParsingException("message", new Exception("error")));
-
-            processor.ParseAndPublishCoverage(_config, token, _mockParser.Object).Wait();
-
-            Assert.IsTrue(logger.Log.Contains("error: message System.Exception: error"));
-
-            logger.Log = "";
-
-            _mockParser.Setup(x => x.GetFileCoverageInfos()).Throws(new Exception("error"));
-
-            processor.ParseAndPublishCoverage(_config, token, _mockParser.Object).Wait();
-
-            Assert.IsTrue(logger.Log.Contains("error: An error occured while publishing coverage files. System.Exception: error"));
-        }
     }
 }

--- a/src/CoveragePublisher/CoverageProcessor.cs
+++ b/src/CoveragePublisher/CoverageProcessor.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Pipelines.CoveragePublisher.Model;
 using Microsoft.Azure.Pipelines.CoveragePublisher.Parsers;
+using Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublisher;
 using Microsoft.Azure.Pipelines.CoveragePublisher.Utils;
 using Microsoft.VisualStudio.Services.WebApi;
 
@@ -44,7 +46,12 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
                     if (supportsFileCoverageJson)
                     {
                         TraceLogger.Debug("Publishing file json coverage is supported.");
-                        var fileCoverage = parser.GetFileCoverageInfos();
+
+                        bool hasDotCoverageFiles = config.CoverageFiles.Any(file => Path.GetExtension(file) == Constants.CoverageFormats.CoverageDotFileFormat);
+                        bool hasCoverageXFiles = config.CoverageFiles.Any(file => Path.GetExtension(file) == Constants.CoverageFormats.CoverageXFileExtension);
+                        bool hasCoverageBFiles = config.CoverageFiles.Any(file => Path.GetExtension(file) == Constants.CoverageFormats.CoverageBFileExtension);
+
+                        var fileCoverage = (hasDotCoverageFiles || hasCoverageXFiles || hasCoverageBFiles) ? parser.GetFileCoverageInfos(token) : parser.GetFileCoverageInfos();
 
                         _telemetry.AddOrUpdate("UniqueFilesCovered", fileCoverage.Count);
 

--- a/src/CoveragePublisher/CoveragePublisher.csproj
+++ b/src/CoveragePublisher/CoveragePublisher.csproj
@@ -14,6 +14,9 @@
     <PackageReference Include="Microsoft.TeamFoundation.PublishTestResults" Version="16.199.0-preview" />
     <PackageReference Include="ReportGenerator.Core" Version="5.1.19" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CodeCoverage" Version="17.8.0" />
+    <PackageReference Include="Microsoft.CodeCoverage.IO" Version="17.7.0" />
+    <PackageReference Include="Serilog" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CoveragePublisher/Model/ICoverageParserTool.cs
+++ b/src/CoveragePublisher/Model/ICoverageParserTool.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Threading;
 
 namespace Microsoft.Azure.Pipelines.CoveragePublisher.Model
 {
@@ -15,7 +16,13 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Model
         /// </summary>
         /// <returns>List of <see cref="FileCoverageInfo"/></returns>
         List<FileCoverageInfo> GetFileCoverageInfos();
-        
+
+        /// <summary>
+        /// Get coverage information for individual files. Specifically used for .coverage/.covx scenarios
+        /// </summary>
+        /// <returns>List of <see cref="FileCoverageInfo"/></returns>
+        List<FileCoverageInfo> GetFileCoverageInfos(CancellationToken token);
+
         /// <summary>
         /// Get coverage summary, contains combined coverage summary data.
         /// </summary>

--- a/src/CoveragePublisher/Parsers/CoverageParserTools/PublisherCoverageFileConfiguration.cs
+++ b/src/CoveragePublisher/Parsers/CoverageParserTools/PublisherCoverageFileConfiguration.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.Azure.Pipelines.CoveragePublisher.Model;
+using Microsoft.CodeCoverage.Core;
+using Microsoft.CodeCoverage.IO.Coverage;
+using Microsoft.TeamFoundation.TestManagement.WebApi;
+using Palmmedia.ReportGenerator.Core;
+using Palmmedia.ReportGenerator.Core.CodeAnalysis;
+using Palmmedia.ReportGenerator.Core.Parser;
+using Palmmedia.ReportGenerator.Core.Parser.Filtering;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.IO;
+
+namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers.CoverageParserTools
+{
+    internal class PublisherCoverageFileConfiguration : ICoverageFileConfiguration
+    {
+        /// <inheritdoc/>
+        public bool ReadModules { get; set; }
+
+        /// <inheritdoc/>
+        public bool ReadSkippedModules { get; set; }
+
+        /// <inheritdoc/>
+        public bool ReadSkippedFunctions { get; set; }
+
+        /// <inheritdoc/>
+        public bool ReadSnapshotsData { get; set; }
+
+        /// <inheritdoc/>
+        public bool GenerateCoverageBufferFiles { get; set; }
+
+        /// <inheritdoc/>
+        public bool FixCoverageBuffersMismatch { get; set; }
+
+        /// <inheritdoc/>
+        public int MaxDegreeOfParallelism { get; set; } = 10;
+
+        public bool SkipInvalidData { get; set; }
+
+        public CoverageMergeOperation MergeOperation { get; set; }
+
+        internal static PublisherCoverageFileConfiguration Default { get; } = new PublisherCoverageFileConfiguration
+        {
+            ReadModules = true,
+            ReadSkippedFunctions = true,
+            ReadSnapshotsData = true,
+            ReadSkippedModules = true,
+            GenerateCoverageBufferFiles = true,
+            FixCoverageBuffersMismatch = true,
+        };
+
+        internal static PublisherCoverageFileConfiguration NoSkippedData { get; } = new PublisherCoverageFileConfiguration
+        {
+            ReadModules = true,
+            ReadSkippedFunctions = false,
+            ReadSnapshotsData = true,
+            ReadSkippedModules = false,
+            GenerateCoverageBufferFiles = true,
+            FixCoverageBuffersMismatch = true,
+        };
+    }
+}

--- a/src/CoveragePublisher/Parsers/CoverageParserTools/ReportGeneratorTool.cs
+++ b/src/CoveragePublisher/Parsers/CoverageParserTools/ReportGeneratorTool.cs
@@ -94,10 +94,8 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
                               nativeCoverageFile.EndsWith(Constants.CoverageFormats.CoverageBFileExtension)
                               ))
                 {
-                    Console.WriteLine("THESE ARE DOTCOVERAGE FILES");
                     var transformedXml = TransformCoverageFilesToXml(Configuration.CoverageFiles, token);
                     Console.WriteLine("TRANSFORMED COVERAGE TO XML");
-                    Console.WriteLine(transformedXml.ToString());
 
                     _parserResult = ParseCoverageFiles(transformedXml.Result);
 
@@ -108,7 +106,6 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
 
             if (Configuration.CoverageFiles == null)
             {
-                Console.WriteLine("THIS IS TRUE");
                 return fileCoverages;
             }
 
@@ -118,7 +115,6 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
                 {
                     foreach (var file in @class.Files)
                     {
-                        Console.WriteLine("WE HAVE REACHED THE THRIPLE FOR LOOP");
                         FileCoverageInfo resultFileCoverageInfo = new FileCoverageInfo { FilePath = file.Path, LineCoverageStatus = new Dictionary<uint, TeamFoundation.TestManagement.WebApi.CoverageStatus>() };
                         int lineNumber = 0;
 

--- a/src/CoveragePublisher/Parsers/CoverageParserTools/ReportGeneratorTool.cs
+++ b/src/CoveragePublisher/Parsers/CoverageParserTools/ReportGeneratorTool.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Azure.Pipelines.CoveragePublisher.Model;
 using Microsoft.TeamFoundation.TestManagement.WebApi;
+using Microsoft.CodeCoverage.Core;
 using Palmmedia.ReportGenerator.Core;
 using Palmmedia.ReportGenerator.Core.CodeAnalysis;
 using Palmmedia.ReportGenerator.Core.Parser;
@@ -12,6 +13,14 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Serilog;
+using Microsoft.CodeCoverage.IO;
+using Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublisher;
+using Microsoft.Azure.Pipelines.CoveragePublisher.Parsers.CoverageParserTools;
 
 namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
 {
@@ -50,14 +59,14 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
                 {
                     foreach (var file in @class.Files)
                     {
-                        FileCoverageInfo resultFileCoverageInfo = new FileCoverageInfo { FilePath = file.Path, LineCoverageStatus = new Dictionary<uint, CoverageStatus>() };
+                        FileCoverageInfo resultFileCoverageInfo = new FileCoverageInfo { FilePath = file.Path, LineCoverageStatus = new Dictionary<uint, TeamFoundation.TestManagement.WebApi.CoverageStatus>() };
                         int lineNumber = 0;
 
                         foreach (var line in file.LineCoverage)
                         {
                             if (line != -1 && lineNumber != 0)
                             {
-                                resultFileCoverageInfo.LineCoverageStatus.Add((uint)lineNumber, line == 0 ? CoverageStatus.NotCovered : CoverageStatus.Covered);
+                                resultFileCoverageInfo.LineCoverageStatus.Add((uint)lineNumber, line == 0 ? TeamFoundation.TestManagement.WebApi.CoverageStatus.NotCovered : TeamFoundation.TestManagement.WebApi.CoverageStatus.Covered);
                             }
                             ++lineNumber;
                         }
@@ -68,6 +77,87 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
             }
 
             return fileCoverages;
+        }
+
+        public List<FileCoverageInfo> GetFileCoverageInfos(CancellationToken token)
+        {
+            TraceLogger.Debug("ReportGeneratorTool.GetFileCoverageInfos: Generating file coverage info from coverage files.");
+
+            List<FileCoverageInfo> fileCoverages = new List<FileCoverageInfo>();
+
+            Console.WriteLine($"These are the Configuration NAtive Coverage files: {Configuration.CoverageFiles}");
+
+            foreach (string nativeCoverageFile in Configuration.CoverageFiles)
+            {
+                if ((nativeCoverageFile.EndsWith(Constants.CoverageFormats.CoverageDotFileFormat) ||
+                              nativeCoverageFile.EndsWith(Constants.CoverageFormats.CoverageXFileExtension) ||
+                              nativeCoverageFile.EndsWith(Constants.CoverageFormats.CoverageBFileExtension)
+                              ))
+                {
+                    Console.WriteLine("THESE ARE DOTCOVERAGE FILES");
+                    var transformedXml = TransformCoverageFilesToXml(Configuration.CoverageFiles, token);
+                    Console.WriteLine("TRANSFORMED COVERAGE TO XML");
+                    Console.WriteLine(transformedXml.ToString());
+
+                    _parserResult = ParseCoverageFiles(transformedXml.Result);
+
+                }
+            }
+
+            Console.WriteLine("These are the Parser Results", _parserResult);
+
+            if (Configuration.CoverageFiles == null)
+            {
+                Console.WriteLine("THIS IS TRUE");
+                return fileCoverages;
+            }
+
+            foreach (var assembly in _parserResult.Assemblies)
+            {
+                foreach (var @class in assembly.Classes)
+                {
+                    foreach (var file in @class.Files)
+                    {
+                        Console.WriteLine("WE HAVE REACHED THE THRIPLE FOR LOOP");
+                        FileCoverageInfo resultFileCoverageInfo = new FileCoverageInfo { FilePath = file.Path, LineCoverageStatus = new Dictionary<uint, TeamFoundation.TestManagement.WebApi.CoverageStatus>() };
+                        int lineNumber = 0;
+
+                        foreach (var line in file.LineCoverage)
+                        {
+                            if (line != -1 && lineNumber != 0)
+                            {
+                                resultFileCoverageInfo.LineCoverageStatus.Add((uint)lineNumber, line == 0 ? TeamFoundation.TestManagement.WebApi.CoverageStatus.NotCovered : TeamFoundation.TestManagement.WebApi.CoverageStatus.Covered);
+                            }
+                            ++lineNumber;
+                        }
+
+                        fileCoverages.Add(resultFileCoverageInfo);
+                    }
+                }
+            }
+
+            Console.WriteLine("FILECOVERAGE", fileCoverages.Count);
+
+            return fileCoverages;
+        }
+
+        private async Task<List<string>> TransformCoverageFilesToXml(IList<string> inputCoverageFiles, CancellationToken cancellationToken)
+        {
+            // Customers like intune invoke vstest.console.exe multiple times inside a single job. Transform cov files resulting from each run into a different subdirectory
+            var utility = new CoverageFileUtilityV2(PublisherCoverageFileConfiguration.Default);
+
+            var transformedXmls = new List<string>();
+            foreach (var coverageFile in inputCoverageFiles)
+            {
+                string transformedXml = Path.ChangeExtension(coverageFile, ".xml");
+                await utility.ToXmlFileAsync(
+                    path: coverageFile,
+                    outputPath: transformedXml,
+                    cancellationToken: cancellationToken);
+
+                transformedXmls.Add(transformedXml);
+            }
+            return transformedXmls;
         }
 
         public CoverageSummary GetCoverageSummary()

--- a/src/CoveragePublisher/Parsers/CoverageParserTools/ReportGeneratorTool.cs
+++ b/src/CoveragePublisher/Parsers/CoverageParserTools/ReportGeneratorTool.cs
@@ -87,20 +87,12 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
 
             Console.WriteLine($"These are the Configuration NAtive Coverage files: {Configuration.CoverageFiles}");
 
-            foreach (string nativeCoverageFile in Configuration.CoverageFiles)
-            {
-                if ((nativeCoverageFile.EndsWith(Constants.CoverageFormats.CoverageDotFileFormat) ||
-                              nativeCoverageFile.EndsWith(Constants.CoverageFormats.CoverageXFileExtension) ||
-                              nativeCoverageFile.EndsWith(Constants.CoverageFormats.CoverageBFileExtension)
-                              ))
-                {
-                    var transformedXml = TransformCoverageFilesToXml(Configuration.CoverageFiles, token);
-                    Console.WriteLine("TRANSFORMED COVERAGE TO XML");
 
-                    _parserResult = ParseCoverageFiles(transformedXml.Result);
+            var transformedXml = TransformCoverageFilesToXml(Configuration.CoverageFiles, token);
+            Console.WriteLine("TRANSFORMED COVERAGE TO XML");
 
-                }
-            }
+            _parserResult = ParseCoverageFiles(transformedXml.Result);
+
 
             Console.WriteLine("These are the Parser Results", _parserResult);
 
@@ -143,15 +135,21 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
             var utility = new CoverageFileUtilityV2(PublisherCoverageFileConfiguration.Default);
 
             var transformedXmls = new List<string>();
-            foreach (var coverageFile in inputCoverageFiles)
+            foreach (var nativeCoverageFile in inputCoverageFiles)
             {
-                string transformedXml = Path.ChangeExtension(coverageFile, ".xml");
-                await utility.ToXmlFileAsync(
-                    path: coverageFile,
-                    outputPath: transformedXml,
-                    cancellationToken: cancellationToken);
+                if ((nativeCoverageFile.EndsWith(Constants.CoverageFormats.CoverageDotFileFormat) ||
+                            nativeCoverageFile.EndsWith(Constants.CoverageFormats.CoverageXFileExtension) ||
+                            nativeCoverageFile.EndsWith(Constants.CoverageFormats.CoverageBFileExtension)
+                            ))
+                {
+                    string transformedXml = Path.ChangeExtension(nativeCoverageFile, ".xml");
+                    await utility.ToXmlFileAsync(
+                        path: nativeCoverageFile,
+                        outputPath: transformedXml,
+                        cancellationToken: cancellationToken);
 
-                transformedXmls.Add(transformedXml);
+                    transformedXmls.Add(transformedXml);
+                }
             }
             return transformedXmls;
         }

--- a/src/CoveragePublisher/Parsers/Parser.cs
+++ b/src/CoveragePublisher/Parsers/Parser.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using Microsoft.Azure.Pipelines.CoveragePublisher.Model;
 using Microsoft.Azure.Pipelines.CoveragePublisher.Utils;
 
@@ -33,6 +34,20 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
                 var tool = _coverageParserTool.Value;
                 GenerateHTMLReport(tool);
                 return tool.GetFileCoverageInfos();
+            }
+            catch (Exception ex)
+            {
+                throw new ParsingException(Resources.ParsingError, ex);
+            }
+        }
+
+        public virtual List<FileCoverageInfo> GetFileCoverageInfos(CancellationToken token)
+        {
+            try
+            {
+                var tool = _coverageParserTool.Value;
+                GenerateHTMLReport(tool);
+                return tool.GetFileCoverageInfos(token);
             }
             catch (Exception ex)
             {

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Constants.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Constants.cs
@@ -40,5 +40,12 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
             public const string EnablePublishToTcmServiceDirectlyFromTaskFF = "TestManagement.Server.EnablePublishToTcmServiceDirectlyFromTask";
             public const string TestLogStoreOnTCMService = "TestManagement.Server.TestLogStoreOnTCMService";
         }
+
+        internal static class CoverageFormats
+        {
+            public const string CoverageDotFileFormat = ".coverage";
+            public const string CoverageXFileExtension = ".covx";
+            public const string CoverageBFileExtension = ".covb";
+        }
     }
 }


### PR DESCRIPTION
PR description - Here , we are adding the abilities to support all the code coverage formats with the PCCRV2. So with these changes, we can now pass the .coverage/.covx files as well to the PCCRV2 and those would be converted to the cjson format and we would get the cjson file view in the code coverage tab. 