### PR TITLE
Updating the package versions

### DIFF
--- a/src/CoveragePublisher/CoveragePublisher.csproj
+++ b/src/CoveragePublisher/CoveragePublisher.csproj
@@ -10,11 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.199.0-preview" />
-    <PackageReference Include="Microsoft.TeamFoundation.PublishTestResults" Version="16.199.0-preview" />
-    <PackageReference Include="ReportGenerator.Core" Version="5.1.19" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.239.0-preview" />
+    <PackageReference Include="Microsoft.TeamFoundation.PublishTestResults" Version="19.239.0-preview" />
+    <PackageReference Include="ReportGenerator.Core" Version="5.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 


### PR DESCRIPTION
PR Description - The Coveragepublisher library was using some of the old versions of the following dependencies. This leads to compliance issues. Following is the example where the build failed due to the library using older version of Sql.DataClient
https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=28222416&view=results

Passing PR build (after updating the versions)- https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=28229563&view=results

This old dependency is used in the Microsoft.TeamFoundationServer.Client
1) We were using 16.199 version of this library which is quite old. The latest version https://www.nuget.org/packages/Microsoft.TeamFoundationServer.Client/19.239.0-preview
 offers better capabilities wrt compliance and security and will also resolve the build failure. Similarly, we need to upgrade Microsoft.TeamFoundation.PublishTestResults as well to the latest version as its dependent on it. We cannot use the old version of this package , it wont be compatible

2) We also need to use the latest version of ReportGenerator as it contains some bug fixes for jacoco format and is better than the previous version https://github.com/danielpalme/ReportGenerator/releases/tag/v5.3.0

3) Newtonsoft.Json was updated since 13.0.1 was not compatible with the latest version of Microsoft.TeamFoundationServer.Client

Testing:

Build passed 
![image](https://github.com/microsoft/azure-pipelines-coveragepublisher/assets/110326599/d8c2bd9e-b4fe-4422-b1b7-570429096846)


Tests passed
![image](https://github.com/microsoft/azure-pipelines-coveragepublisher/assets/110326599/3848a987-084d-43f8-9e14-f4badb176e2c)

Code Coverage tab

![image](https://github.com/microsoft/azure-pipelines-coveragepublisher/assets/110326599/c57e652e-faa5-42fa-96d2-8d42390a18f1)

Folder level view :

![image](https://github.com/microsoft/azure-pipelines-coveragepublisher/assets/110326599/dbc7ba8e-9b6c-4d5c-acb3-862b08f72b48)


