### PR TITLE
Publishing the html coverage report in CoveragePublisher library

### DIFF
--- a/src/CoveragePublisher/CoverageProcessor.cs
+++ b/src/CoveragePublisher/CoverageProcessor.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
 
                         TraceLogger.Debug("Publishing code coverage summary supported");
 
-                        if (summary == null || (IsCodeCoverageData  && IsCoverageStats  && summary.CodeCoverageData.CoverageStats.Count == 0)) 
+                        if (summary == null || (IsCodeCoverageData && IsCoverageStats && summary.CodeCoverageData.CoverageStats.Count == 0))
                         {
                             TraceLogger.Warning(Resources.NoSummaryStatisticsGenerated);
                         }
@@ -109,29 +109,30 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
                         }
                     }
 
-                    //Feature Flag for testing and deprecating PublishHTMLReport; To be cleaned up post PCCRV2 upgrade
-                    if (!uploadNativeCoverageFilesToLogStore && config.GenerateHTMLReport)
+                    //Feature Flag for PublishHTMLReport; To be cleaned up post PCCRV2 upgrade
+                    if (config.GenerateHTMLReport)
+                    {
+                        if (!Directory.Exists(config.ReportDirectory))
                         {
-                            if (!Directory.Exists(config.ReportDirectory))
+                            TraceLogger.Warning(Resources.NoReportDirectoryGenerated);
+                        }
+
+                        else
+                        {
+                            using (new SimpleTimer("CoverageProcesser", "PublishHTMLReport", _telemetry))
                             {
-                                TraceLogger.Warning(Resources.NoReportDirectoryGenerated);
-                            }
-                            else
-                            {
-                                using (new SimpleTimer("CoverageProcesser", "PublishHTMLReport", _telemetry))
-                                {
-                                    await _publisher.PublishHTMLReport(config.ReportDirectory, token);
-                                }
+                                await _publisher.PublishHTMLReport(config.ReportDirectory, token);
                             }
                         }
+                    }
                 }
                 // Only catastrophic failures should trickle down to these catch blocks
-                catch(ParsingException ex)
+                catch (ParsingException ex)
                 {
                     _telemetry.AddFailure(ex);
                     TraceLogger.Error($"{ex.Message} {ex.InnerException}");
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     _telemetry.AddFailure(ex);
                     TraceLogger.Error(string.Format(Resources.ErrorOccuredWhilePublishing, ex));


### PR DESCRIPTION
In the following PR, we are trying to invoke the PublishHTMLReport method to add the html reports in the CoveragePublisher repo. This is part of the feature parity changes for the PCCRV2. Adding this change will allow PCCRV2 to generate the html reports which would also contain the line-based coverage details with clickable links like the functionality we had in the PCCRV1. 

Note: There will be few UI changes, which I will be rasing in the subsequent PRs. 

Testing :

![image](https://github.com/user-attachments/assets/e0f0e0c2-2e34-4aa6-804e-8cac6df0f82a)
