### PR TITLE
Removing the Feature flag for TestLogStore in CoveragePublisher

### DIFF
--- a/src/CoveragePublisher.Tests/CoverageProcessorTests.cs
+++ b/src/CoveragePublisher.Tests/CoverageProcessorTests.cs
@@ -55,7 +55,6 @@ namespace CoveragePublisher.Tests
 
             summary.AddCoverageStatistics("", 0, 0, CoverageSummary.Priority.Class);
 
-            _mockPublisher.Setup(x => x.IsFileCoverageJsonSupported()).Returns(false);
             _mockParser.Setup(x => x.GetCoverageSummary()).Returns(summary);
 
             processor.ParseAndPublishCoverage(_config, token, _mockParser.Object).Wait();
@@ -72,7 +71,6 @@ namespace CoveragePublisher.Tests
             var processor = new CoverageProcessor(_mockPublisher.Object, _mockTelemetryDataCollector.Object);
             var coverage = new List<FileCoverageInfo>();
 
-            _mockPublisher.Setup(x => x.IsFileCoverageJsonSupported()).Returns(true);
             _mockParser.Setup(x => x.GetFileCoverageInfos()).Returns(coverage);
 
             processor.ParseAndPublishCoverage(_config, token, _mockParser.Object).Wait();
@@ -92,7 +90,6 @@ namespace CoveragePublisher.Tests
             var processor = new CoverageProcessor(_mockPublisher.Object, _mockTelemetryDataCollector.Object);
             var coverage = new List<FileCoverageInfo>();
 
-            _mockPublisher.Setup(x => x.IsFileCoverageJsonSupported()).Returns(true);
             _mockParser.Setup(x => x.GetFileCoverageInfos()).Throws(new ParsingException("message", new Exception("error")));
 
             processor.ParseAndPublishCoverage(_config, token, _mockParser.Object).Wait();
@@ -125,7 +122,6 @@ namespace CoveragePublisher.Tests
                 new FileCoverageInfo()
             };
 
-            _mockPublisher.Setup(x => x.IsFileCoverageJsonSupported()).Returns(true);
             _mockPublisher.Setup(x => x.IsUploadNativeFilesToTCMSupported()).Returns(true);
             _mockParser.Setup(x => x.GetFileCoverageInfos()).Returns(coverage);
 
@@ -150,10 +146,8 @@ namespace CoveragePublisher.Tests
 
             summary.AddCoverageStatistics("", 3, 3, CoverageSummary.Priority.Class);
 
-            _mockPublisher.Setup(x => x.IsFileCoverageJsonSupported()).Returns(false);
             _mockParser.Setup(x => x.GetCoverageSummary()).Returns(summary);
 
-            _mockPublisher.Setup(x => x.IsFileCoverageJsonSupported()).Returns(true);
             _mockParser.Setup(x => x.GetFileCoverageInfos()).Returns(coverage);
 
             processor.ParseAndPublishCoverage(_config, token, _mockParser.Object).Wait();
@@ -176,7 +170,6 @@ namespace CoveragePublisher.Tests
 
             summary.AddCoverageStatistics("", 0, 0, CoverageSummary.Priority.Class);
 
-            _mockPublisher.Setup(x => x.IsFileCoverageJsonSupported()).Returns(false);
             _mockParser.Setup(x => x.GetCoverageSummary()).Returns(summary);
 
             processor.ParseAndPublishCoverage(_config, token, _mockParser.Object).Wait();

--- a/src/CoveragePublisher/CoverageProcessor.cs
+++ b/src/CoveragePublisher/CoverageProcessor.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
                         "}";
                     });
 
-                    var supportsFileCoverageJson = _publisher.IsFileCoverageJsonSupported();
                     var uploadNativeCoverageFilesToLogStore = _publisher.IsUploadNativeFilesToTCMSupported();
                     _telemetry.AddOrUpdate("uploadNativeCoverageFilesToLogStore", uploadNativeCoverageFilesToLogStore.ToString());
 
@@ -53,62 +52,43 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
 
                         await _publisher.PublishNativeCoverageFiles(config.CoverageFiles, token);
                     }
-                    if (supportsFileCoverageJson)
+
+                    var fileCoverage = parser.GetFileCoverageInfos();
+
+                    var summary = parser.GetCoverageSummary();
+
+                    bool IsCodeCoverageData = (summary.CodeCoverageData != null);
+
+                    bool IsCoverageStats = (summary.CodeCoverageData.CoverageStats != null);
+
+                    _telemetry.AddOrUpdate("UniqueFilesCovered", fileCoverage.Count);
+
+                    TraceLogger.Debug("Publishing code coverage summary supported");
+
+                    if (summary == null || (IsCodeCoverageData && IsCoverageStats && summary.CodeCoverageData.CoverageStats.Count == 0))
                     {
-                        var fileCoverage = parser.GetFileCoverageInfos();
-
-                        var summary = parser.GetCoverageSummary();
-
-                        bool IsCodeCoverageData = (summary.CodeCoverageData != null);
-
-                        bool IsCoverageStats = (summary.CodeCoverageData.CoverageStats != null);
-
-                        _telemetry.AddOrUpdate("UniqueFilesCovered", fileCoverage.Count);
-
-                        TraceLogger.Debug("Publishing code coverage summary supported");
-
-                        if (summary == null || (IsCodeCoverageData && IsCoverageStats && summary.CodeCoverageData.CoverageStats.Count == 0))
-                        {
-                            TraceLogger.Warning(Resources.NoSummaryStatisticsGenerated);
-                        }
-                        else
-                        {
-                            using (new SimpleTimer("CoverageProcesser", "PublishCoverageSummary", _telemetry))
-                            {
-                                await _publisher.PublishCoverageSummary(summary, token);
-                            }
-                        }
-
-                        if (fileCoverage.Count == 0)
-                        {
-                            TraceLogger.Warning(Resources.NoCoverageFilesGenerated);
-                        }
-                        else
-                        {
-                            using (new SimpleTimer("CoverageProcesser", "PublishFileCoverage", _telemetry))
-                            {
-                                await _publisher.PublishFileCoverage(fileCoverage, token);
-                            }
-                        }
+                        TraceLogger.Warning(Resources.NoSummaryStatisticsGenerated);
                     }
                     else
                     {
-                        TraceLogger.Debug("Publishing file json coverage is not supported.");
-                        var summary = parser.GetCoverageSummary();
-
-                        if (summary == null || summary.CodeCoverageData.CoverageStats.Count == 0)
+                        using (new SimpleTimer("CoverageProcesser", "PublishCoverageSummary", _telemetry))
                         {
-                            TraceLogger.Warning(Resources.NoSummaryStatisticsGenerated);
-                        }
-                        else
-                        {
-                            using (new SimpleTimer("CoverageProcesser", "PublishCoverageSummary", _telemetry))
-                            {
-                                await _publisher.PublishCoverageSummary(summary, token);
-                            }
+                            await _publisher.PublishCoverageSummary(summary, token);
                         }
                     }
 
+                    if (fileCoverage.Count == 0)
+                    {
+                        TraceLogger.Warning(Resources.NoCoverageFilesGenerated);
+                    }
+                    else
+                    {
+                        using (new SimpleTimer("CoverageProcesser", "PublishFileCoverage", _telemetry))
+                        {
+                            await _publisher.PublishFileCoverage(fileCoverage, token);
+                        }
+                    }
+                    
                     //Feature Flag for PublishHTMLReport; To be cleaned up post PCCRV2 upgrade
                     if (config.GenerateHTMLReport)
                     {

--- a/src/CoveragePublisher/Model/Publishers/ICoveragePublisher.cs
+++ b/src/CoveragePublisher/Model/Publishers/ICoveragePublisher.cs
@@ -42,11 +42,6 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Model
         Task PublishHTMLReport(string reportDirectory, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Gets weather publisher supports publishing <see cref="FileCoverageInfo"/> format.
-        /// </summary>
-        bool IsFileCoverageJsonSupported();
-
-        /// <summary>
         /// Gets weather we can upload native file to tcm logstore.
         /// </summary>
         /// <returns></returns>

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/AzurePipelinesPublisher.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/AzurePipelinesPublisher.cs
@@ -64,11 +64,6 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
             _logStoreHelper = new LogStoreHelper(_clientFactory);
         }
 
-        public bool IsFileCoverageJsonSupported()
-        {
-            return _featureFlagHelper.GetFeatureFlagState(Constants.FeatureFlags.TestLogStoreOnTCMService, true);
-        }
-
         public async Task PublishCoverageSummary(CoverageSummary coverageSummary, CancellationToken cancellationToken)
         {
             var coverageData = coverageSummary.CodeCoverageData;

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Constants.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Constants.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
         {
             public const string EnablePublishToTcmServiceDirectlyFromTaskFF = "TestManagement.Server.EnablePublishToTcmServiceDirectlyFromTask";
             public const string UploadNativeCoverageFilesToLogStore = "TestManagement.Server.UploadNativeCoverageFilesToLogStore";
-            public const string TestLogStoreOnTCMService = "TestManagement.Server.TestLogStoreOnTCMService";
         }
         internal static class CoverageConstants
         {


### PR DESCRIPTION
This feature flag is used to enable new test log store on tcm. This is already turned on for all the rings. 

Once this Feature flag is removed it will also help in resolving this feedback ticket - https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2224746

Next Feature flag to be removed is the UploadNAtiveCodeCoverageFiles

![image](https://github.com/user-attachments/assets/7a642a8a-a72b-41fb-a368-beb57dea9d4f)


Testing:

![image](https://github.com/user-attachments/assets/602a8522-46d9-403d-9906-9468660fa45f)
