### PR TITLE
Removing NativeCoverage Feature flag

### DIFF
--- a/src/CoveragePublisher.Tests/CoverageProcessorTests.cs
+++ b/src/CoveragePublisher.Tests/CoverageProcessorTests.cs
@@ -34,16 +34,8 @@ namespace CoveragePublisher.Tests
             _mockPublisher.Setup(x => x.PublishCoverageSummary(It.IsAny<CoverageSummary>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
             _mockPublisher.Setup(x => x.PublishNativeCoverageFiles(It.IsAny<IList<string>>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
             _mockPublisher.Setup(x => x.PublishFileCoverage(It.IsAny<IList<FileCoverageInfo>>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-            _mockPublisher.Setup(x => x.IsUploadNativeFilesToTCMSupported()).Returns(false);
             _mockFFHelper.Reset();
             _featureFlagHelper = featureFlagHelper;
-            var IsUploadNativeFilesToTCMSupported = _publisher.IsUploadNativeFilesToTCMSupported;
-
-            if (IsUploadNativeFilesToTCMSupported.Equals(false))
-            {
-                // Feature Flag for testing and deprecating PublishHTMLReport; To be cleaned up post PCCRV2 upgrade
-                _mockPublisher.Setup(x => x.PublishHTMLReport(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-            }
         }
 
         [TestMethod]
@@ -122,7 +114,6 @@ namespace CoveragePublisher.Tests
                 new FileCoverageInfo()
             };
 
-            _mockPublisher.Setup(x => x.IsUploadNativeFilesToTCMSupported()).Returns(true);
             _mockParser.Setup(x => x.GetFileCoverageInfos()).Returns(coverage);
 
             _mockPublisher.Verify(x => x.PublishNativeCoverageFiles(

--- a/src/CoveragePublisher/CoverageProcessor.cs
+++ b/src/CoveragePublisher/CoverageProcessor.cs
@@ -42,16 +42,10 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
                         "}";
                     });
 
-                    var uploadNativeCoverageFilesToLogStore = _publisher.IsUploadNativeFilesToTCMSupported();
-                    _telemetry.AddOrUpdate("uploadNativeCoverageFilesToLogStore", uploadNativeCoverageFilesToLogStore.ToString());
+                    // Upload native coverage files to TCM
+                    TraceLogger.Debug("Publishing native coverage files is supported.");
 
-                    if (uploadNativeCoverageFilesToLogStore)
-                    {
-                        // Upload native coverage files to TCM
-                        TraceLogger.Debug("Publishing native coverage files is supported.");
-
-                        await _publisher.PublishNativeCoverageFiles(config.CoverageFiles, token);
-                    }
+                    await _publisher.PublishNativeCoverageFiles(config.CoverageFiles, token);
 
                     var fileCoverage = parser.GetFileCoverageInfos();
 

--- a/src/CoveragePublisher/Model/Publishers/ICoveragePublisher.cs
+++ b/src/CoveragePublisher/Model/Publishers/ICoveragePublisher.cs
@@ -40,11 +40,5 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Model
         /// <param name="reportDirectory">Path to coverage report directory.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
         Task PublishHTMLReport(string reportDirectory, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Gets weather we can upload native file to tcm logstore.
-        /// </summary>
-        /// <returns></returns>
-        bool IsUploadNativeFilesToTCMSupported();
     }
 }

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/AzurePipelinesPublisher.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/AzurePipelinesPublisher.cs
@@ -163,11 +163,6 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
             await _htmlReportPublisher.PublishHTMLReportAsync(reportDirectory, token);
         }
 
-        public bool IsUploadNativeFilesToTCMSupported()
-        {
-            return _featureFlagHelper.GetFeatureFlagState(Constants.FeatureFlags.UploadNativeCoverageFilesToLogStore, true);
-        }
-
         public async Task PublishNativeCoverageFiles(IList<string> nativeCoverageFiles, CancellationToken cancellationToken)
         {
             if (nativeCoverageFiles == null || nativeCoverageFiles.Count == 0)

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Constants.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Constants.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
         internal static class FeatureFlags
         {
             public const string EnablePublishToTcmServiceDirectlyFromTaskFF = "TestManagement.Server.EnablePublishToTcmServiceDirectlyFromTask";
-            public const string UploadNativeCoverageFilesToLogStore = "TestManagement.Server.UploadNativeCoverageFilesToLogStore";
         }
         internal static class CoverageConstants
         {


### PR DESCRIPTION
This feature flag is used to upload native coverage files like .coverage/covx/covb/cjson to the logstore . This is already turned on for all the rings.

Once this Feature flag is removed it will also help in resolving this feedback ticket - https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/2224746

Feature flag states

![image](https://github.com/user-attachments/assets/d8e64145-bc56-402c-83fa-515146d1d961)
