### PR TITLE
Dont publish html files for native coverage like .coverage/covx/covb

### DIFF
--- a/src/CoveragePublisher/CoverageProcessor.cs
+++ b/src/CoveragePublisher/CoverageProcessor.cs
@@ -95,11 +95,11 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
                         {
                             foreach (string nativeCoverageFile in config.CoverageFiles)
                             {
-                                if (!(nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageBufferFileExtension) ||
-                                    nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageFileExtension) ||
-                                    nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageBFileExtension) ||
-                                    nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageJsonFileExtension) ||
-                                    nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageXFileExtension)))
+                                if (!(nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageBufferFileExtension) || // .coveragebuffer
+                                    nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageFileExtension) ||         // .coverage
+                                    nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageBFileExtension) ||        //.covb 
+                                    nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageJsonFileExtension) ||     //.cjson  
+                                    nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageXFileExtension)))         // .covx
                                 {
                                     using (new SimpleTimer("CoverageProcesser", "PublishHTMLReport", _telemetry))
                                     {

--- a/src/CoveragePublisher/CoverageProcessor.cs
+++ b/src/CoveragePublisher/CoverageProcessor.cs
@@ -93,11 +93,23 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
 
                         else
                         {
-                            using (new SimpleTimer("CoverageProcesser", "PublishHTMLReport", _telemetry))
+                            foreach (string nativeCoverageFile in config.CoverageFiles)
                             {
-                                await _publisher.PublishHTMLReport(config.ReportDirectory, token);
+                                if (!(nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageBufferFileExtension) ||
+                                    nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageFileExtension) ||
+                                    nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageBFileExtension) ||
+                                    nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageJsonFileExtension) ||
+                                    nativeCoverageFile.EndsWith(Constants.CoverageConstants.CoverageXFileExtension)))
+                                {
+                                    using (new SimpleTimer("CoverageProcesser", "PublishHTMLReport", _telemetry))
+                                    {
+                                        await _publisher.PublishHTMLReport(config.ReportDirectory, token);
+                                    }
+                                }
+
                             }
                         }
+                              
                     }
                 }
                 // Only catastrophic failures should trickle down to these catch blocks


### PR DESCRIPTION
PR description -Dont publish html artifacts for coverage files like .coverage , covx/covb, coveragebuffer and cjson. 

Reason - When we process any of the aforementioned files with the publish code coverage v2 task, our intention is to upload them to the logstore without generating HTML files. We plan to generate HTML files as build artifacts exclusively for coverage XML files such as Cobertura, JaCoCo, LCOV, GCOV, Clover, and similar formats. These HTML reports will be displayed in the code coverage tab. For the other files, generating HTML files is unnecessary as they would not be able to parse them correctly and the resulting HTML would not contain accurate information.


Testing for PCCRV2

![image](https://github.com/user-attachments/assets/88e3d1bb-b880-42c8-8458-a80a86b5e3fe)


