### PR TITLE
Create scalable design for file upload in PCCRv2

### DIFF
--- a/src/CoveragePublisher.Tests/Publishers/AzurePipelines/Services/FileContainerServiceTests.cs
+++ b/src/CoveragePublisher.Tests/Publishers/AzurePipelines/Services/FileContainerServiceTests.cs
@@ -289,7 +289,8 @@ namespace CoveragePublisher.Tests
 
             var service = new FileContainerService(_mockClientHelper.Object, _context);
 
-            var files = Directory.GetFiles(_uploadDirectory, "*", SearchOption.AllDirectories);
+            var filesArray = Directory.GetFiles(_uploadDirectory, "*", SearchOption.AllDirectories);
+            var files = new List<string>(filesArray);
             var result = await InvokePrivateAsync<List<string>>(service, "ParallelUploadOptimizedAsync", files, _uploadDirectory, _containerPath, 2, CancellationToken.None);
 
             Assert.AreEqual(0, result.Count);

--- a/src/CoveragePublisher.Tests/Publishers/AzurePipelines/Services/FileContainerServiceTests.cs
+++ b/src/CoveragePublisher.Tests/Publishers/AzurePipelines/Services/FileContainerServiceTests.cs
@@ -274,6 +274,128 @@ namespace CoveragePublisher.Tests
             Assert.IsTrue(_logger.Log.Contains("Uploading 4 files."), $"Logger output: {_logger.Log}");
             Assert.IsTrue(_logger.Log.Contains(string.Format(@"File: '{0}{1}file1' took", _uploadDirectory, Path.DirectorySeparatorChar)));
         }
+
+        [TestMethod]
+        public async Task ParallelUploadOptimizedAsync_UploadsAllFiles()
+        {
+            _mockClientHelper.Setup(x => x.UploadFileAsync(
+                It.IsAny<long>(),
+                It.IsAny<string>(),
+                It.IsAny<FileStream>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<int>()
+            )).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Created));
+
+            var service = new FileContainerService(_mockClientHelper.Object, _context);
+
+            var files = Directory.GetFiles(_uploadDirectory, "*", SearchOption.AllDirectories);
+            var result = await InvokePrivateAsync<List<string>>(service, "ParallelUploadOptimizedAsync", files, _uploadDirectory, _containerPath, 2, CancellationToken.None);
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public async Task ProcessBatchAsync_UploadsBatchFiles()
+        {
+            _mockClientHelper.Setup(x => x.UploadFileAsync(
+                It.IsAny<long>(),
+                It.IsAny<string>(),
+                It.IsAny<FileStream>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<int>()
+            )).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Created));
+
+            var service = new FileContainerService(_mockClientHelper.Object, _context);
+
+            var files = Directory.GetFiles(_uploadDirectory, "*", SearchOption.AllDirectories);
+            var batch = new List<string> { files[0], files[1] };
+            var result = await InvokePrivateAsync<List<string>>(service, "ProcessBatchAsync", batch, _uploadDirectory, _containerPath, 2, CancellationToken.None);
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public async Task UploadOptimizedAsync_UploadsFilesFromQueue()
+        {
+            _mockClientHelper.Setup(x => x.UploadFileAsync(
+                It.IsAny<long>(),
+                It.IsAny<string>(),
+                It.IsAny<FileStream>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<int>()
+            )).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Created));
+
+            var service = new FileContainerService(_mockClientHelper.Object, _context);
+
+            // Enqueue files manually
+            var files = Directory.GetFiles(_uploadDirectory, "*", SearchOption.AllDirectories);
+            var queueField = typeof(FileContainerService).GetField("_fileUploadQueue", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var queue = (System.Collections.Concurrent.ConcurrentQueue<string>)queueField.GetValue(service);
+            foreach (var file in files)
+                queue.Enqueue(file);
+
+            var result = await InvokePrivateAsync<List<string>>(service, "UploadOptimizedAsync", _uploadDirectory, _containerPath, CancellationToken.None);
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        [TestMethod]
+        public async Task UploadSingleFileWithBackoffAsync_SucceedsOnFirstTry()
+        {
+            _mockClientHelper.Setup(x => x.UploadFileAsync(
+                It.IsAny<long>(),
+                It.IsAny<string>(),
+                It.IsAny<FileStream>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<int>()
+            )).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Created));
+
+            var service = new FileContainerService(_mockClientHelper.Object, _context);
+
+            var files = Directory.GetFiles(_uploadDirectory, "*", SearchOption.AllDirectories);
+            var result = await InvokePrivateAsync<bool>(service, "UploadSingleFileWithBackoffAsync", files[0], _uploadDirectory, _containerPath, _context.ContainerId, _context.ProjectId, CancellationToken.None);
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        public async Task UploadAsync_UploadsFilesFromQueue()
+        {
+            _mockClientHelper.Setup(x => x.UploadFileAsync(
+                It.IsAny<long>(),
+                It.IsAny<string>(),
+                It.IsAny<FileStream>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<int>()
+            )).ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Created));
+
+            var service = new FileContainerService(_mockClientHelper.Object, _context);
+
+            // Enqueue files manually
+            var files = Directory.GetFiles(_uploadDirectory, "*", SearchOption.AllDirectories);
+            var queueField = typeof(FileContainerService).GetField("_fileUploadQueue", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var queue = (System.Collections.Concurrent.ConcurrentQueue<string>)queueField.GetValue(service);
+            foreach (var file in files)
+                queue.Enqueue(file);
+
+            var result = await InvokePrivateAsync<List<string>>(service, "UploadAsync", _uploadDirectory, _containerPath, CancellationToken.None);
+
+            Assert.AreEqual(0, result.Count);
+        }
+
+        private static async Task<T> InvokePrivateAsync<T>(object obj, string methodName, params object[] args)
+        {
+            var method = obj.GetType().GetMethod(methodName, System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var task = (Task)method.Invoke(obj, args);
+            await task.ConfigureAwait(false);
+            var resultProperty = task.GetType().GetProperty("Result");
+            return (T)resultProperty.GetValue(task);
+        }
     }
 }
-   
+

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Constants.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Constants.cs
@@ -48,5 +48,11 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
             public const string CoverageBFileExtension = ".covb";
             public const string CoverageJsonFileExtension = ".cjson";
         }
+        internal static class BatchUploadConfig
+        {
+            public const int DefaultChunkSize = 4 * 1024 * 1024;
+            public const int ConcurrentUploadsMax = 8;
+            public const int BatchSize = 50;
+        }
 	}
 }

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Constants.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Constants.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
         internal static class FeatureFlags
         {
             public const string EnablePublishToTcmServiceDirectlyFromTaskFF = "TestManagement.Server.EnablePublishToTcmServiceDirectlyFromTask";
+            public const string EnableBatchingInFileUploadFF = "TestManagement.Server.EnableBatchingInFileUploadFromCodeCoverageTask";
         }
         internal static class CoverageConstants
         {

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Helpers/FeatureFlagHelper.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Helpers/FeatureFlagHelper.cs
@@ -36,6 +36,23 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
             return true;
         }
 
+        public bool GetFeatureFlagStateForTcm(string featureFlagName)
+        {
+            try
+            {
+                var featureFlag = GetClient(true).GetFeatureFlagByNameAsync(featureFlagName).Result;
+                if (featureFlag != null && featureFlag.EffectiveState.Equals("On", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                return false;
+            }
+            return false;
+        }
+
         private FeatureAvailabilityHttpClient GetClient(bool isTcmFeature)
         {
             if(isTcmFeature)

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Helpers/FeatureFlagHelper.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Helpers/FeatureFlagHelper.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
             }
             catch
             {
+                TraceLogger.Debug(string.Format(Resources.FailedToGetFeatureFlag, featureFlagName));
                 return false;
             }
             return false;

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Helpers/FeatureFlagHelper.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Helpers/FeatureFlagHelper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.TeamFoundation.TestClient.PublishTestResults;
 using Microsoft.VisualStudio.Services.FeatureAvailability.WebApi;
 
@@ -36,11 +37,11 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
             return true;
         }
 
-        public bool GetFeatureFlagStateForTcm(string featureFlagName)
+        public async Task<bool> GetFeatureFlagStateForTcm(string featureFlagName)
         {
             try
             {
-                var featureFlag = GetClient(true).GetFeatureFlagByNameAsync(featureFlagName).Result;
+                var featureFlag = await GetClient(true).GetFeatureFlagByNameAsync(featureFlagName);
                 if (featureFlag != null && featureFlag.EffectiveState.Equals("On", StringComparison.OrdinalIgnoreCase))
                 {
                     return true;

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Resources.Designer.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Resources.Designer.cs
@@ -323,5 +323,32 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
                 return ResourceManager.GetString("TotalUploadFiles", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Artifact upload completed: {0} succeeded, {1} failed.
+        /// </summary>
+        internal static string ArtifactUploadCompleted {
+            get {
+                return ResourceManager.GetString("ArtifactUploadCompleted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Processing batch {0}: files {1}-{2} of {3}.
+        /// </summary>
+        internal static string ProcessingBatch {
+            get {
+                return ResourceManager.GetString("ProcessingBatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error in upload: {0}.
+        /// </summary>
+        internal static string ErrorInUpload {
+            get {
+                return ResourceManager.GetString("ErrorInUpload", resourceCulture);
+            }
+        }
     }
 }

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Resources.resx
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Resources.resx
@@ -204,4 +204,13 @@
   <data name="FailedToUploadNativeCoverageFiles" xml:space="preserve">
     <value>Failed to upload native coverage files. Exception: {1}</value>
   </data>
+  <data name="ArtifactUploadCompleted" xml:space="preserve">
+    <value>Artifact upload completed: {0} succeeded, {1} failed</value>
+  </data>
+  <data name="ProcessingBatch" xml:space="preserve">
+    <value>Processing batch {0}: files {1}-{2} of {3}</value>
+  </data>
+  <data name="ErrorInUpload" xml:space="preserve">
+    <value>Error in upload: {0}</value>
+  </data>
 </root>

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
             _fileContainerHelper = new FileContainerClientHelper(clientFactory);
             _context = context;
             _featureFlagHelper = new FeatureFlagHelper(clientFactory);
-            isBatchingEnabled = true; //_featureFlagHelper.GetFeatureFlagStateForTcm(Constants.FeatureFlags.EnableBatchingInFileUploadFF);
+            isBatchingEnabled = _featureFlagHelper.GetFeatureFlagStateForTcm(Constants.FeatureFlags.EnableBatchingInFileUploadFF);
         }
 
         public FileContainerService(IFileContainerClientHelper fileContainerHelper, IPipelinesExecutionContext context)

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
         {
             _fileContainerHelper = fileContainerHelper;
             _context = context;
+            _featureFlagHelper = new FeatureFlagHelper(new TestClientFactory()); // <-- Add this line
         }
 
         /// <summary>

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
@@ -245,7 +245,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
 
             for (int i = 0; i < actualWorkers; i++)
             {
-                uploadTasks.Add(UploadWorkerPipelineStyleAsync(sourceParentDirectory, containerPath, cancellationToken));
+                uploadTasks.Add(UploadOptimizedAsync(sourceParentDirectory, containerPath, cancellationToken));
             }
 
             await Task.WhenAll(uploadTasks);
@@ -259,7 +259,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
             return failedFiles;
         }
 
-        private async Task<List<string>> UploadWorkerPipelineStyleAsync(string sourceParentDirectory, string containerPath, CancellationToken cancellationToken)
+        private async Task<List<string>> UploadOptimizedAsync(string sourceParentDirectory, string containerPath, CancellationToken cancellationToken)
         {
             var failedFiles = new List<string>();
             var containerId = _context.ContainerId;

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
@@ -1,4 +1,4 @@
-﻿﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
             _fileContainerHelper = new FileContainerClientHelper(clientFactory);
             _context = context;
             _featureFlagHelper = new FeatureFlagHelper(clientFactory);
-            isBatchingEnabled = _featureFlagHelper.GetFeatureFlagStateForTcm(Constants.FeatureFlags.EnableBatchingInFileUploadFF);
+            isBatchingEnabled = true; //_featureFlagHelper.GetFeatureFlagStateForTcm(Constants.FeatureFlags.EnableBatchingInFileUploadFF);
         }
 
         public FileContainerService(IFileContainerClientHelper fileContainerHelper, IPipelinesExecutionContext context)

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
@@ -339,9 +339,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
                         await Task.Delay(delays[attempt], cancellationToken);
                     }
 
-                    // Updated itemPath logic as requested
-                    var relativePath = Path.GetRelativePath(sourceParentDirectory, fileToUpload);
-                    var itemPath = Path.Combine(containerPath.TrimEnd('/'), relativePath).Replace('\\', '/');
+                    var itemPath = (containerPath.TrimEnd('/') + "/" + fileToUpload.Remove(0, sourceParentDirectory.Length + 1)).Replace('\\', '/');
 
                     using (var fs = File.Open(fileToUpload, FileMode.Open, FileAccess.Read, FileShare.Read))
                     {

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
             _fileContainerHelper = new FileContainerClientHelper(clientFactory);
             _context = context;
             _featureFlagHelper = new FeatureFlagHelper(clientFactory);
-            isBatchingEnabled = _featureFlagHelper.GetFeatureFlagStateForTcm(Constants.FeatureFlags.EnableBatchingInFileUploadFF);
         }
 
         public FileContainerService(IFileContainerClientHelper fileContainerHelper, IPipelinesExecutionContext context)
@@ -59,6 +58,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
             string sourceParentDirectory;
             var uploadDirectory = directoryAndcontainerPath.Item1;
             var containerPath = directoryAndcontainerPath.Item2;
+            isBatchingEnabled = await _featureFlagHelper.GetFeatureFlagStateForTcm(Constants.FeatureFlags.EnableBatchingInFileUploadFF);
 
             List<string> files;
             files = Directory.EnumerateFiles(uploadDirectory, "*", SearchOption.AllDirectories).ToList();

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
         private const int defaultChunkSize = Constants.BatchUploadConfig.DefaultChunkSize;
         private const int concurrentUploadsMax = Constants.BatchUploadConfig.ConcurrentUploadsMax;
         private const int batchSize = Constants.BatchUploadConfig.BatchSize;
+        
         private bool isBatchingEnabled = false;
 
         private int filesProcessed = 0;

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
@@ -24,9 +24,9 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
         private readonly IPipelinesExecutionContext _context;
         private readonly FeatureFlagHelper _featureFlagHelper;
         
-        private const int defaultChunkSize = 4 * 1024 * 1024;
-        private const int concurrentUploadsMax = 8;
-        private const int batchSize = 50;
+        private const int defaultChunkSize = Constants.BatchUploadConfig.DefaultChunkSize;
+        private const int concurrentUploadsMax = Constants.BatchUploadConfig.ConcurrentUploadsMax;
+        private const int batchSize = Constants.BatchUploadConfig.BatchSize;
         private bool isBatchingEnabled = false;
 
         private int filesProcessed = 0;

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
@@ -43,7 +43,6 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
         {
             _fileContainerHelper = fileContainerHelper;
             _context = context;
-            _featureFlagHelper = new FeatureFlagHelper(new TestClientFactory()); // <-- Add this line
         }
 
         /// <summary>
@@ -59,8 +58,10 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
             string sourceParentDirectory;
             var uploadDirectory = directoryAndcontainerPath.Item1;
             var containerPath = directoryAndcontainerPath.Item2;
-            isBatchingEnabled = await _featureFlagHelper.GetFeatureFlagStateForTcm(Constants.FeatureFlags.EnableBatchingInFileUploadFF);
-
+            if (_featureFlagHelper != null)
+            {
+                isBatchingEnabled = await _featureFlagHelper.GetFeatureFlagStateForTcm(Constants.FeatureFlags.EnableBatchingInFileUploadFF);
+            }
             List<string> files;
             files = Directory.EnumerateFiles(uploadDirectory, "*", SearchOption.AllDirectories).ToList();
             sourceParentDirectory = uploadDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);

--- a/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
+++ b/src/CoveragePublisher/Publishers/DefaultPublisher/Services/FileContainerService.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Publishers.DefaultPublishe
         private readonly ConcurrentDictionary<string, ConcurrentQueue<string>> _fileUploadProgressLog = new ConcurrentDictionary<string, ConcurrentQueue<string>>();
         private readonly IFileContainerClientHelper _fileContainerHelper;
         private readonly IPipelinesExecutionContext _context;
-        private readonly IFeatureFlagHelper _featureFlagHelper;
+        private readonly FeatureFlagHelper _featureFlagHelper;
         
         private const int defaultChunkSize = 4 * 1024 * 1024;
         private const int concurrentUploadsMax = 8;


### PR DESCRIPTION
**We are creating scalable design for coverage files upload in PCCRv2 by adding batching logic and other design changes**

### Current design

Task is not able to upload more than ~1k coverage files, resulting in failure to publish code coverage artifact. Thus we do not get clickable code coverage in code coverage tab

**Example (FF: TestManagement.Server.EnableBatchingInFileUploadFromCodeCoverageTask undefined)**

Code coverage tab

![image](https://github.com/user-attachments/assets/a914523d-5158-4d5f-982b-4f61b1c346a8)

Logs (upload unfinished, still exits with success)

![image](https://github.com/user-attachments/assets/d6494e5f-95e6-4558-900d-a35c3b707756)

### Scalable design

Task will be able to upload till ~7k coverage files with batching logic and other design changes enabled and we can get clickable code coverage in code coverage tab. This is ~7x improvement from the current design

**Example (FF: TestManagement.Server.EnableBatchingInFileUploadFromCodeCoverageTask ON)**

Code coverage tab

![image](https://github.com/user-attachments/assets/37839ca1-3f18-42a5-ba75-0b9ba3526fe4)

Logs (upload finished)

![image](https://github.com/user-attachments/assets/5ab9d6be-1297-4770-923c-99e9f562b072)

**~7k files upload**

![image](https://github.com/user-attachments/assets/da745c7a-aaab-4dcf-b587-1b74a17333b0)

![image](https://github.com/user-attachments/assets/df57699d-0a9d-492e-858f-4b74e86c9b24)

