### PR TITLE
Update ReportGenerator.Core package version to 5.5.0

### DIFF
--- a/src/CoveragePublisher/CoveragePublisher.csproj
+++ b/src/CoveragePublisher/CoveragePublisher.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.239.0-preview" />
     <PackageReference Include="Microsoft.TeamFoundation.PublishTestResults" Version="19.239.0-preview" />
-    <PackageReference Include="ReportGenerator.Core" Version="5.3.0" />
+    <PackageReference Include="ReportGenerator.Core" Version="5.5.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />


### PR DESCRIPTION
We are upgrading the reportGenerator version here to resolve the compliance goverance issues related to the System.Text.Json. Since the Root dependencies for System.Text.Json is the ReportGenerator.Core library. 

Testing - Done with PCCRV2

<img width="2709" height="1445" alt="image" src="https://github.com/user-attachments/assets/450c8f93-9331-41f9-9cb7-aab7ebaed244" />
