### PR TITLE
bug: Pass on source directories from Configuration to coverage parser downstream 

### DIFF
--- a/src/CoveragePublisher/Parsers/CoverageParserTools/ReportGeneratorTool.cs
+++ b/src/CoveragePublisher/Parsers/CoverageParserTools/ReportGeneratorTool.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
 
             var sourceDirectories = string.IsNullOrWhiteSpace(Configuration.SourceDirectory)
                 ? new string[] { }
-                : Configuration.SourceDirectory.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                : Configuration.SourceDirectory.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 
             CoverageReportParser parser = new CoverageReportParser(1, 1, sourceDirectories, new DefaultFilter(new string[] { }),
                 new DefaultFilter(new string[] { }),

--- a/src/CoveragePublisher/Parsers/CoverageParserTools/ReportGeneratorTool.cs
+++ b/src/CoveragePublisher/Parsers/CoverageParserTools/ReportGeneratorTool.cs
@@ -143,7 +143,11 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
         {
             TraceLogger.Debug("ReportGeneratorTool.ParseCoverageFiles: Parsing coverage files.");
 
-            CoverageReportParser parser = new CoverageReportParser(1, 1, new string[] { }, new DefaultFilter(new string[] { }),
+            var sourceDirectories = string.IsNullOrWhiteSpace(Configuration.SourceDirectory)
+                ? new string[] { }
+                : Configuration.SourceDirectory.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+            CoverageReportParser parser = new CoverageReportParser(1, 1, sourceDirectories, new DefaultFilter(new string[] { }),
                 new DefaultFilter(new string[] { }),
                 new DefaultFilter(new string[] { }));
 


### PR DESCRIPTION
Currently the configured source directories are not given to the downstream `CoverageReportParser` leading to issues like this in the pipeline:

> 2026-02-18T10:13:50:   No source directories supplied for 'JaCoCo' coverage file

The source directories are hardcoded to an empty array. Modified it to actually use the semicolon separated string from the configuration and populate the source directory array.
