### PR TITLE
Add --parallelism CLI option for multi-threaded coverage parsing

### DIFF
--- a/src/CoveragePublisher/ArgumentsProcessor.cs
+++ b/src/CoveragePublisher/ArgumentsProcessor.cs
@@ -28,6 +28,9 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
 
             [Option("noTelemetry", Default = false, HelpText = "Disable telemetry data collection.")]
             public override bool DisableTelemetry { get; set; }
+
+            [Option("parallelism", Default = 1, HelpText = "Number of reports to parse/merge in parallel. Defaults to 1 (single-threaded).")]
+            public override int Parallelism { get; set; }
         }
 
 

--- a/src/CoveragePublisher/Model/PublisherConfiguration.cs
+++ b/src/CoveragePublisher/Model/PublisherConfiguration.cs
@@ -44,5 +44,11 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Model
         /// Gets the configuration for whether telemetry is disabled.
         /// </summary>
         virtual public bool DisableTelemetry { get; set; }
+
+        /// <summary>
+        /// Number of coverage reports to parse and merge in parallel.
+        /// Defaults to 1 (single-threaded). Set higher for parallel parsing.
+        /// </summary>
+        virtual public int Parallelism { get; set; } = 1;
     }
 }

--- a/src/CoveragePublisher/Parsers/CoverageParserTools/ReportGeneratorTool.cs
+++ b/src/CoveragePublisher/Parsers/CoverageParserTools/ReportGeneratorTool.cs
@@ -143,7 +143,11 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
         {
             TraceLogger.Debug("ReportGeneratorTool.ParseCoverageFiles: Parsing coverage files.");
 
-            CoverageReportParser parser = new CoverageReportParser(1, 1, new string[] { }, new DefaultFilter(new string[] { }),
+            int parallelism = Math.Max(1, Configuration.Parallelism);
+
+            TraceLogger.Debug($"ReportGeneratorTool.ParseCoverageFiles: Using parallelism {parallelism} (ProcessorCount: {Environment.ProcessorCount}).");
+
+            CoverageReportParser parser = new CoverageReportParser(parallelism, parallelism, new string[] { }, new DefaultFilter(new string[] { }),
                 new DefaultFilter(new string[] { }),
                 new DefaultFilter(new string[] { }));
 


### PR DESCRIPTION
## Summary

`CoverageReportParser` in `ReportGeneratorTool.cs` is hardcoded to
single-threaded parsing and merging:

```csharp
new CoverageReportParser(1, 1, ...)
```

This PR adds a `--parallelism` CLI option so users can opt in to parallel
report parsing when processing many coverage files.

## Changes

- Add `Parallelism` property to `PublisherConfiguration` (default: `1`)
- Add `--parallelism` CLI option to `CoveragePublisher.Console`
- Use the value for both `numberOfReportsParsedInParallel` and
  `numberOfReportsMergedInParallel` in `CoverageReportParser`
- Add debug logging of parallelism value

## Backwards compatibility

Default remains `1` — no behavior change for existing users. Parallel parsing
is opt-in via `--parallelism N`.

## Related

- AB#2354931