### PR TITLE
Generate HTML report only once per Parser instance

### DIFF
--- a/src/CoveragePublisher.Tests/Parser/ParserTests.cs
+++ b/src/CoveragePublisher.Tests/Parser/ParserTests.cs
@@ -147,6 +147,35 @@ debug: Parser.GenerateHTMLReport: Copying summary file SampleCoverage/JaCoCo.xml
         }
 
         [TestMethod]
+        public void WillOnlyGenerateHTMLReportOnceAcrossMultipleParserCalls()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(tempDir);
+
+            var mockTool = new Mock<ICoverageParserTool>();
+            mockTool.Setup(x => x.GenerateHTMLReport());
+            mockTool.Setup(x => x.GetFileCoverageInfos()).Returns(new List<FileCoverageInfo>());
+            mockTool.Setup(x => x.GetCoverageSummary()).Returns(new CoverageSummary());
+
+            var config = new PublisherConfiguration()
+            {
+                CoverageFiles = new List<string>() { "SampleCoverage/Cobertura.xml" },
+                ReportDirectory = tempDir
+            };
+
+            var parser = new TestParser(config, _mockTelemetry.Object, mockTool.Object);
+
+            parser.GetFileCoverageInfos();
+            parser.GetCoverageSummary();
+
+            mockTool.Verify(x => x.GenerateHTMLReport(), Times.Once);
+            Assert.AreEqual(1, Directory.EnumerateDirectories(tempDir, "Summary_*").Count());
+
+            //cleanup
+            Directory.Delete(tempDir, true);
+        }
+
+        [TestMethod]
         public void ParsingException()
         {
             var mockTool = new Mock<ICoverageParserTool>();

--- a/src/CoveragePublisher/Parsers/Parser.cs
+++ b/src/CoveragePublisher/Parsers/Parser.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
         private PublisherConfiguration _configuration;
         private Lazy<ICoverageParserTool> _coverageParserTool;
         private ITelemetryDataCollector _telemetry;
+        private bool _htmlReportGenerated;
 
         public Parser(PublisherConfiguration config, ITelemetryDataCollector telemetry)
         {
@@ -56,7 +57,13 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
 
         protected virtual void GenerateHTMLReport(ICoverageParserTool tool)
         {
-            if (_configuration.GenerateHTMLReport)
+            // Both GetFileCoverageInfos() and GetCoverageSummary() call into this method,
+            // and CoverageProcessor invokes both in sequence. ReportGenerator is expensive
+            // (minutes for large reports - see issue #72) and produces identical output on
+            // every call against the same _parserResult, so render only once per Parser
+            // instance. On failure, leave _htmlReportGenerated = false so the next caller
+            // gets a retry, matching the existing swallow-and-log semantics.
+            if (_configuration.GenerateHTMLReport && !_htmlReportGenerated)
             {
                 try
                 {
@@ -95,6 +102,8 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
                             TraceLogger.Debug("Parser.GenerateHTMLReport: Directory " + _configuration.ReportDirectory + " doesn't exist, skipping copying of coverage input files.");
                         }
                     }
+
+                    _htmlReportGenerated = true;
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Fix #72.

Parser.GenerateHTMLReport() is invoked from both GetFileCoverageInfos() and GetCoverageSummary(), and CoverageProcessor calls both in sequence. Each call re-runs the full ReportGenerator pipeline against the same already-cached _parserResult and re-copies all input coverage files into a new Summary_<guid> subdirectory, even though the output is byte-identical.

On a real Visual Studio Editor CI build with ~3,800 classes the publish step measured 12m37s end-to-end: 5m6s for pass 1, 5m41s for the duplicate pass 2, and only 1m46s for the actual upload. Cutting the duplicate pass roughly halves the publish step.

Add a _htmlReportGenerated flag on Parser and short-circuit subsequent calls. The flag is set inside the try after the render and file-copy both succeed, so existing swallow-and-log-on-failure semantics are preserved (a first-call failure still gives the second call a chance to retry). _parserResult was already cached in ReportGeneratorTool's constructor; this extends that one-shot semantic to the HTML render step.