### PR TITLE
Update azure-pipelines.yml for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,139 +1,183 @@
 # .NET Desktop
 # Build and run tests for .NET Desktop or Windows classic desktop solutions.
-# Add steps that publish symbols, save build artifacts, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
+# Migrated to the 1ES Pipeline Template (governed). Reference:
+# https://eng.ms/docs/coreai/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/migration/overview-new
 
 trigger:
 - master
 
-pool:
-  vmImage: 'windows-latest'
-
 variables:
-  solution: '**/*.sln'
-  buildPlatform: 'Any CPU'
-  buildConfiguration: 'Release'
+  - name: solution
+    value: '**/*.sln'
+  - name: buildPlatform
+    value: 'Any CPU'
+  - name: buildConfiguration
+    value: 'Release'
+  # ---- 1ES governance knobs (kept in sync with Scripts/testpipeline.yml) ----
+  - name: PipelineClassification_Audited
+    value: Production
+  - name: PipelineGovernanceStatus_Audited
+    value: true
+  - name: policy_service.build_task_injection.enabled
+    value: true
+  - name: skipComponentGovernanceDetection
+    value: true
 
-steps:
-- task: Powershell@2
-  displayName: Copyright notice check
-  inputs:
-    targetType: inline
-    script: |
-      $arr = Get-ChildItem -Recurse .\src\**\*.cs
-      $files = @()
-      foreach ($file in $arr) {
-          if ($file.Name -ne "Resources.Designer.cs" -and $file.FullName -notmatch "\\obj\\") {
-              $content = $(Get-Content $file.FullName -First 2)
-              $first = $content | select -First 1
-              $second = $content | select -First 1 -Skip 1
-              if ($first -ne "// Copyright (c) Microsoft Corporation. All rights reserved." -and $second -ne "// Licensed under the MIT license. See LICENSE file in the project root for full license information.") {
-                  $files += $file.FullName
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+# The 1ES Official template only permits production branches (master, releases/*).
+# For private / topic / PR branches we fall back to the Unofficial template so
+# builds keep validating without being on a production branch. Production
+# branches keep the Official template so SDL enforcement and audited publishing
+# continue to run.
+extends:
+  ${{ if or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/heads/releases/')) }}:
+    template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  ${{ else }}:
+    template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
+  parameters:
+    pool:
+      name: 1ESPtTfsAgentBuildPool1
+    stages:
+    - stage: Build
+      jobs:
+      - job: Build
+        displayName: Build, test and publish CoveragePublisher
+        templateContext:
+          # Governed artifact publishing. Replaces the legacy PublishBuildArtifacts@1
+          # task — 1ES injects the compliant publish step (with SBOM / provenance)
+          # at the correct point in the job.
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Publish CoveragePublisher artifact'
+            condition: ne(variables['Build.Reason'], 'PullRequest')
+            targetPath: '$(Build.ArtifactStagingDirectory)'
+            artifactName: CoveragePublisher
+        steps:
+        - task: PowerShell@2
+          displayName: Copyright notice check
+          inputs:
+            targetType: inline
+            script: |
+              $arr = Get-ChildItem -Recurse .\src\**\*.cs
+              $files = @()
+              foreach ($file in $arr) {
+                  if ($file.Name -ne "Resources.Designer.cs" -and $file.FullName -notmatch "\\obj\\") {
+                      $content = $(Get-Content $file.FullName -First 2)
+                      $first = $content | select -First 1
+                      $second = $content | select -First 1 -Skip 1
+                      if ($first -ne "// Copyright (c) Microsoft Corporation. All rights reserved." -and $second -ne "// Licensed under the MIT license. See LICENSE file in the project root for full license information.") {
+                          $files += $file.FullName
+                      }
+                  }
               }
-          }
-      }
-      if ($files.Length -gt 0) {
-          write-host "##vso[task.logissue type=error]All code files must contain the following copyright notice."
-          write-host "`n// Copyright (c) Microsoft Corporation. All rights reserved.`n// Licensed under the MIT license. See LICENSE file in the project root for full license information.`n`nThe following files are missing copyright notice."
-          foreach ($filename in $files) {
-              write-host $filename
-          }
-      }
+              if ($files.Length -gt 0) {
+                  write-host "##vso[task.logissue type=error]All code files must contain the following copyright notice."
+                  write-host "`n// Copyright (c) Microsoft Corporation. All rights reserved.`n// Licensed under the MIT license. See LICENSE file in the project root for full license information.`n`nThe following files are missing copyright notice."
+                  foreach ($filename in $files) {
+                      write-host $filename
+                  }
+              }
 
-- task: NuGetToolInstaller@1
+        - task: NuGetToolInstaller@1
+          displayName: Install NuGet
 
-- task: NuGetCommand@2
-  inputs:
-    restoreSolution: '$(solution)'
+        - task: NuGetCommand@2
+          displayName: NuGet restore
+          inputs:
+            restoreSolution: '$(solution)'
 
-- task: UseDotNet@2
-  displayName: 'Use .NET Core sdk 7.0.x'
-  inputs:
-    version: 7.0.x
+        - task: UseDotNet@2
+          displayName: 'Use .NET SDK 7.0.x'
+          inputs:
+            version: 7.0.x
 
+        - task: DotNetCoreCLI@2
+          displayName: Build solution
+          inputs:
+            command: 'build'
+            projects: '**/*.sln'
+            feedsToUse: 'select'
+            versioningScheme: 'off'
+            arguments: '-c $(buildConfiguration)'
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'build'
-    projects: '**/*.sln'
-    feedsToUse: 'select'
-    versioningScheme: 'off'
-    arguments: '-c Release'
+        - task: DotNetCoreCLI@2
+          displayName: Run L0/L1 tests
+          inputs:
+            command: 'test'
+            projects: '**/*.Tests.csproj'
+            arguments: '--collect "Code coverage"'
+            testRunTitle: 'L0/L1'
+            feedsToUse: 'select'
+            versioningScheme: 'off'
 
-- task: DotNetCoreCLI@2
-  inputs:
-    command: 'test'
-    projects: '**/*.Tests.csproj'
-    arguments: '--collect "Code coverage"'
-    testRunTitle: 'L0/L1'
-    feedsToUse: 'select'
-    versioningScheme: 'off'
+        - task: DotNetCoreCLI@2
+          displayName: 'dotnet publish (win-x64)'
+          inputs:
+            command: publish
+            publishWebProjects: false
+            projects: '**/CoveragePublisher.Console.csproj'
+            arguments: '--no-build -c $(buildConfiguration) -f net7.0 -r win-x64'
+            zipAfterPublish: false
+            modifyOutputPath: false
 
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet publish'
-  inputs:
-    command: publish
-    publishWebProjects: false
-    projects: '**/CoveragePublisher.Console.csproj'
-    arguments: '--no-build -c Release -f net7.0 -r win-x64'
-    zipAfterPublish: false
-    modifyOutputPath: false
+        - task: DotNetCoreCLI@2
+          displayName: 'dotnet publish (linux-x64)'
+          inputs:
+            command: publish
+            publishWebProjects: false
+            projects: '**/CoveragePublisher.Console.csproj'
+            arguments: '-c $(buildConfiguration) -f net7.0 -r linux-x64'
+            zipAfterPublish: false
+            modifyOutputPath: false
 
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet publish for linux'
-  inputs:
-    command: publish
-    publishWebProjects: false
-    projects: '**/CoveragePublisher.Console.csproj'
-    arguments: '-c Release -f net7.0 -r linux-x64'
-    zipAfterPublish: false
-    modifyOutputPath: false
+        - task: DotNetCoreCLI@2
+          displayName: 'dotnet publish (osx-x64)'
+          inputs:
+            command: publish
+            publishWebProjects: false
+            projects: '**/CoveragePublisher.Console.csproj'
+            arguments: '-c $(buildConfiguration) -f net7.0 -r osx-x64'
+            zipAfterPublish: false
+            modifyOutputPath: false
 
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet publish for macos'
-  inputs:
-    command: publish
-    publishWebProjects: false
-    projects: '**/CoveragePublisher.Console.csproj'
-    arguments: '-c Release -f net7.0 -r osx-x64'
-    zipAfterPublish: false
-    modifyOutputPath: false
+        - task: CopyFiles@2
+          displayName: Stage win-x64 payload
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/src/CoveragePublisher.Console/bin/Release/net7.0/win-x64/publish/'
+            Contents: '**'
+            TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
-- task: CopyFiles@2
-  inputs:
-    SourceFolder: '$(Build.SourcesDirectory)/src/CoveragePublisher.Console/bin/Release/net7.0/win-x64/publish/'
-    Contents: '**'
-    TargetFolder: '$(Build.ArtifactStagingDirectory)'
+        - task: CopyFiles@2
+          displayName: Stage linux-x64 payload
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/src/CoveragePublisher.Console/bin/Release/net7.0/linux-x64/publish/'
+            Contents: '**'
+            TargetFolder: '$(Build.ArtifactStagingDirectory)/linux-x64'
 
-- task: CopyFiles@2
-  inputs:
-    SourceFolder: '$(Build.SourcesDirectory)/src/CoveragePublisher.Console/bin/Release/net7.0/linux-x64/publish/'
-    Contents: '**'
-    TargetFolder: '$(Build.ArtifactStagingDirectory)/linux-x64'
+        - task: CopyFiles@2
+          displayName: Stage win-x64 dll + runtimeconfig
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/src/CoveragePublisher.Console/bin/Release/net7.0/win-x64'
+            Contents: |
+              **/*.dll
+              CoveragePublisher.Console.runtimeconfig.json
+            TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
-- task: CopyFiles@2
-  inputs:
-    SourceFolder: '$(Build.SourcesDirectory)/src/CoveragePublisher.Console/bin/Release/net7.0/win-x64'
-    Contents: |
-      **/*.dll
-      CoveragePublisher.Console.runtimeconfig.json
-    TargetFolder: '$(Build.ArtifactStagingDirectory)'
+        - task: CopyFiles@2
+          displayName: Stage osx-x64 payload
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)/src/CoveragePublisher.Console/bin/Release/net7.0/osx-x64/publish/'
+            Contents: '**'
+            TargetFolder: '$(Build.ArtifactStagingDirectory)/osx-x64'
 
-- task: CopyFiles@2
-  inputs:
-    SourceFolder: '$(Build.SourcesDirectory)/src/CoveragePublisher.Console/bin/Release/net7.0/osx-x64/publish/'
-    Contents: '**'
-    TargetFolder: '$(Build.ArtifactStagingDirectory)/osx-x64'
-
-    
-- task: PowerShell@2
-  inputs:
-    targetType: 'inline'
-    script: 'ls $(Build.ArtifactStagingDirectory)'
-
-- task: PublishBuildArtifacts@1
-  condition: ne(variables['Build.Reason'], 'PullRequest')
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-    ArtifactName: 'CoveragePublisher'
-    publishLocation: 'Container'
+        - task: PowerShell@2
+          displayName: List staged artifacts
+          inputs:
+            targetType: 'inline'
+            script: 'Get-ChildItem -Recurse $(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
- Adopted the 1ES governed pipeline template — replaced the top-level pool: + flat steps: with an extends: block targeting v1/1ES.Official.PipelineTemplate.yml@1esPipelines (falls back to 1ES.Unofficial.PipelineTemplate.yml for non-production branches, since Official rejects topic/PR branches).

- Added the 1ES template repository resource — resources.repositories now pins 1ESPipelineTemplates/1ESPipelineTemplates to refs/tags/release under the alias 1esPipelines.
- Switched to a governed pool — replaced vmImage: 'windows-latest' (Microsoft-hosted, disallowed under governance) with the 1ES-managed 1ESPtTfsAgentBuildPool1 used elsewhere in the repo.
 
- Restructured into stages → jobs → steps — moved every existing step under a single Build stage / Build job as required by the 1ES template.

- Added governance variables — PipelineClassification_Audited, PipelineGovernanceStatus_Audited, policy_service.build_task_injection.enabled, skipComponentGovernanceDetection.
- Reformatted the variables: map — rewrote as the typed name/value list required by the 1ES template.
- Fixed the deprecated task casing — Powershell@2 → PowerShell@2.
- Replaced legacy artifact publish with governed output — dropped PublishBuildArtifacts@1 (Container) in favor of a templateContext.outputs block emitting a pipelineArtifact named CoveragePublisher from $(Build.ArtifactStagingDirectory), so 1ES injects the compliant publish step with SBOM/provenance.
- Preserved the original ne(variables['Build.Reason'], 'PullRequest') condition on the artifact publish so PR builds still skip publishing.
- Kept all build logic unchanged — copyright check, NuGet restore, UseDotNet@2 7.0.x, solution build, L0/L1 tests with code coverage, three dotnet publish runs (win-x64 / linux-x64 / osx-x64), and the four CopyFiles@2 staging steps run exactly as before.
- Added displayName labels to every task for readability in the 1ES-rendered pipeline view.

**Testing:**

Ran the pipeline on this PR branch , its working fine

https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=31764715&view=results