### PR TITLE
Added --reportGeneratorArgs command line parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ dotnet CoveragePublisher.Console.dll /path/to/jacoco.xml /path/to/cobertura.xml
 
 ### CLI Options
 
-| Option                | Description                                                |
-| --------------------- | ---------------------------------------------------------- |
-| --reportDirectory     | (Default: "") Path where html report will be generated.    |
-| --sourceDirectory     | (Default: "") List of source directories separated by ';'. |
-| --timeout             | (Default: 120) Timeout for CoveragePublisher in seconds.   |
-| --noTelemetry         | (Default: false) Disable telemetry data collection.        |
-| --help                | Display this help screen.                                  |
+| Option                | Description                                                                                  |
+| --------------------- | -------------------------------------------------------------------------------------------- |
+| --reportDirectory     | (Default: "") Path where html report will be generated.                                      |
+| --sourceDirectory     | (Default: "") List of source directories separated by ';'.                                   |
+| --reportGeneratorArgs | (Default: "") Additional ReportGenerator arguments, in `"-key:value"` form, space separated. |
+| --timeout             | (Default: 120) Timeout for CoveragePublisher in seconds.                                     |
+| --noTelemetry         | (Default: false) Disable telemetry data collection.                                          |
+| --help                | Display this help screen.                                                                    |
 
 # Build & Test
 

--- a/src/CoveragePublisher.Tests/ArgumentsProcessorTests.cs
+++ b/src/CoveragePublisher.Tests/ArgumentsProcessorTests.cs
@@ -19,6 +19,8 @@ namespace CoveragePublisher.Tests
 
             --sourceDirectory    (Default: ) List of source directories separated by ';'.
 
+            --reportGeneratorArgs (Default: ) Additional arguments (in ""-key:value"" form, space separated) to forward to ReportGenerator when generating the HTML report.
+
             --timeout            (Default: 120) Timeout for CoveragePublisher in seconds.
 
             --noTelemetry        (Default: false) Disable telemetry data collection.
@@ -94,6 +96,29 @@ namespace CoveragePublisher.Tests
             {
                 Assert.IsTrue(cliArgs.CoverageFiles.Contains(file));
             }
+        }
+
+        [TestMethod]
+        public void WillParseReportGeneratorArgs()
+        {
+            var argsProcessor = new ArgumentsProcessor();
+
+            var cliArgs = argsProcessor.ProcessCommandLineArgs(new string[] { @"C:\a.txt", "--reportGeneratorArgs=-reporttypes:Cobertura -verbosity:Verbose" });
+
+            Assert.AreEqual("-reporttypes:Cobertura -verbosity:Verbose", cliArgs.ReportGeneratorArguments);
+        }
+
+        [TestMethod]
+        public void WillNotFailWhenReportGeneratorArgsIsNotProvided()
+        {
+            var argsProcessor = new ArgumentsProcessor();
+
+            var cliArgs = argsProcessor.ProcessCommandLineArgs(new string[] { @"C:\a.txt" });
+
+            Assert.IsNotNull(cliArgs);
+            Assert.AreEqual("", cliArgs.ReportGeneratorArguments);
+            Assert.IsTrue(cliArgs.CoverageFiles.Contains(@"C:\a.txt"));
+            Assert.IsFalse(ConsoleWriter.ToString().Contains("ERROR"));
         }
     }
 }

--- a/src/CoveragePublisher.Tests/Parser/Tools/ReportGeneratorToolTests.cs
+++ b/src/CoveragePublisher.Tests/Parser/Tools/ReportGeneratorToolTests.cs
@@ -146,5 +146,111 @@ debug: ReportGeneratorTool.ParseCoverageFiles: Parsing coverage files.
 debug: ReportGeneratorTool.CreateHTMLReportFromParserResult: Creating HTML report.
 ".Trim()));
         }
+
+        [TestMethod]
+        public void WillGenerateHtmlReportWhenReportGeneratorArgumentsIsEmpty()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            var parser = new ReportGeneratorTool(new PublisherConfiguration()
+            {
+                CoverageFiles = new string[] { "SampleCoverage/Cobertura.xml" },
+                ReportDirectory = tempDir,
+                ReportGeneratorArguments = null
+            });
+
+            parser.GenerateHTMLReport();
+
+            Assert.IsTrue(Directory.EnumerateFiles(tempDir, "index.htm").Any());
+
+            Directory.Delete(tempDir, true);
+
+            Assert.IsTrue(_logger.Log.Contains(@"
+debug: ReportGeneratorTool.ParseCoverageFiles: Parsing coverage files.
+debug: ReportGeneratorTool.CreateHTMLReportFromParserResult: Creating HTML report.
+".Trim()));
+        }
+
+        [TestMethod]
+        public void WillPassThroughAdditionalArgumentsWithoutChangingDefaultReportType()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            var parser = new ReportGeneratorTool(new PublisherConfiguration()
+            {
+                CoverageFiles = new string[] { "SampleCoverage/Cobertura.xml" },
+                ReportDirectory = tempDir,
+                ReportGeneratorArguments = "-verbosity:Verbose"
+            });
+
+            parser.GenerateHTMLReport();
+
+            // reporttypes default (HtmlInline_AzurePipelines) is unaffected by the unrelated -verbosity: argument.
+            Assert.IsTrue(Directory.EnumerateFiles(tempDir, "index.htm").Any());
+
+            Directory.Delete(tempDir, true);
+
+            Assert.IsTrue(_logger.Log.Contains(@"
+debug: ReportGeneratorTool.ParseCoverageFiles: Parsing coverage files.
+debug: ReportGeneratorTool.CreateHTMLReportFromParserResult: Creating HTML report.
+".Trim()));
+        }
+
+        [TestMethod]
+        public void WillOverrideDefaultReportTypeWithReportGeneratorArguments()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            var parser = new ReportGeneratorTool(new PublisherConfiguration()
+            {
+                CoverageFiles = new string[] { "SampleCoverage/Cobertura.xml" },
+                ReportDirectory = tempDir,
+                ReportGeneratorArguments = "-reporttypes:Cobertura"
+            });
+
+            parser.GenerateHTMLReport();
+
+            // The user-supplied reporttypes:Cobertura replaces the HtmlInline_AzurePipelines default,
+            // so a Cobertura xml report is generated instead of the html report.
+            Assert.IsTrue(Directory.EnumerateFiles(tempDir, "Cobertura.xml").Any());
+            Assert.IsFalse(Directory.EnumerateFiles(tempDir, "index.htm").Any());
+
+            Directory.Delete(tempDir, true);
+
+            Assert.IsTrue(_logger.Log.Contains(@"
+debug: ReportGeneratorTool.ParseCoverageFiles: Parsing coverage files.
+debug: ReportGeneratorTool.CreateHTMLReportFromParserResult: Creating HTML report.
+".Trim()));
+        }
+
+        [TestMethod]
+        [DataRow("-title:MyTitle", "MyTitle", DisplayName = "No quotes")]
+        [DataRow("-title:\"MyTitle\"", "MyTitle", DisplayName = "Quotes, no spaces")]
+        [DataRow("-title:\"My Custom Title\"", "My Custom Title", DisplayName = "Quotes, spaces")]
+        [DataRow("-title:\"She said \\\"hi\\\"\"", "She said &quot;hi&quot;", DisplayName = "Escaped quotes")]
+        public void WillParseReportGeneratorArgumentValue(string reportGeneratorArguments, string expectedTitle)
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+
+            var parser = new ReportGeneratorTool(new PublisherConfiguration()
+            {
+                CoverageFiles = new string[] { "SampleCoverage/Cobertura.xml" },
+                ReportDirectory = tempDir,
+                ReportGeneratorArguments = reportGeneratorArguments
+            });
+
+            parser.GenerateHTMLReport();
+
+            var indexPath = Path.Combine(tempDir, "index.htm");
+            Assert.IsTrue(File.Exists(indexPath));
+            Assert.IsTrue(File.ReadAllText(indexPath).Contains(expectedTitle));
+
+            Directory.Delete(tempDir, true);
+
+            Assert.IsTrue(_logger.Log.Contains(@"
+debug: ReportGeneratorTool.ParseCoverageFiles: Parsing coverage files.
+debug: ReportGeneratorTool.CreateHTMLReportFromParserResult: Creating HTML report.
+".Trim()));
+        }
     }
 }

--- a/src/CoveragePublisher/ArgumentsProcessor.cs
+++ b/src/CoveragePublisher/ArgumentsProcessor.cs
@@ -23,6 +23,9 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
             [Option("sourceDirectory", Default = "", HelpText = "List of source directories separated by ';'.")]
             override public string SourceDirectory { get; set; }
 
+            [Option("reportGeneratorArgs", Default = "", HelpText = "Additional arguments (in \"-key:value\" form, space separated) to forward to ReportGenerator when generating the HTML report.")]
+            override public string ReportGeneratorArguments { get; set; }
+
             [Option("timeout", Default = 120, HelpText = "Timeout for CoveragePublisher in seconds.")]
             public override int TimeoutInSeconds { get; set; }
 

--- a/src/CoveragePublisher/Model/PublisherConfiguration.cs
+++ b/src/CoveragePublisher/Model/PublisherConfiguration.cs
@@ -44,5 +44,10 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Model
         /// Gets the configuration for whether telemetry is disabled.
         /// </summary>
         virtual public bool DisableTelemetry { get; set; }
+
+        /// <summary>
+        /// Gets additional ReportGenerator arguments, in "-key:value" form, space separated.
+        /// </summary>
+        virtual public string ReportGeneratorArguments { get; set; }
     }
 }

--- a/src/CoveragePublisher/Parsers/CoverageParserTools/ReportGeneratorTool.cs
+++ b/src/CoveragePublisher/Parsers/CoverageParserTools/ReportGeneratorTool.cs
@@ -13,6 +13,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
 {
@@ -118,6 +119,38 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
             return summary;
         }
 
+        private static readonly Regex ReportGeneratorArgumentRegex =
+            new Regex(@"-(?<key>[a-zA-Z]{2,}):(?<value>""(?:[^""\\]|\\.)*""|\S+)", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Parses a "-key:value -key2:value2 ..." string (ReportGenerator's own command line syntax)
+        /// into a case-insensitive dictionary. Quoted values ("...") are supported
+        /// so a value may contain spaces; unquoted values may not. Within a quoted value, \" is
+        /// unescaped to a literal ".
+        /// </summary>
+        private static Dictionary<string, string> ParseReportGeneratorArguments(string arguments)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            if (string.IsNullOrWhiteSpace(arguments))
+            {
+                return result;
+            }
+
+            foreach (Match match in ReportGeneratorArgumentRegex.Matches(arguments))
+            {
+                var value = match.Groups["value"].Value;
+                if (value.Length >= 2 && value[0] == '"' && value[value.Length - 1] == '"')
+                {
+                    value = value.Substring(1, value.Length - 2).Replace("\\\"", "\"");
+                }
+
+                result[match.Groups["key"].Value] = value;
+            }
+
+            return result;
+        }
+
         public void GenerateHTMLReport()
         {
             TraceLogger.Debug("ReportGeneratorTool.CreateHTMLReportFromParserResult: Creating HTML report.");
@@ -127,12 +160,20 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Parsers
                 Directory.CreateDirectory(Configuration.ReportDirectory);
             }
 
-            // Generate the html report with custom configuration for report generator.
-            var reportGeneratorConfig = new ReportConfigurationBuilder().Create(new Dictionary<string, string>() {
+            // Task defaults first, then merge in caller-supplied arguments so that e.g. a
+            // user-supplied -reporttypes: replaces the default instead of being combined with it.
+            var reportGeneratorSettings = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
                 { "targetdir", Configuration.ReportDirectory },
                 { "sourcedirs", string.IsNullOrEmpty(Configuration.SourceDirectory) ? "" : Configuration.SourceDirectory },
                 { "reporttypes", "HtmlInline_AzurePipelines" }
-            });
+            };
+
+            foreach (var kvp in ParseReportGeneratorArguments(Configuration.ReportGeneratorArguments))
+            {
+                reportGeneratorSettings[kvp.Key] = kvp.Value;
+            }
+
+            var reportGeneratorConfig = new ReportConfigurationBuilder().Create(reportGeneratorSettings);
 
             var generator = new Generator();
 


### PR DESCRIPTION
Adds a --reportGeneratorArgs command line parameter that can be used to provide additional arguments to ReportGenerator. Overrides the default arguments that are compiled by the tool, allowing e.g. a different report type to be generated.

The main reason for this is to allow additional features to be added to the CodeCoverageReport@2 task e.g.
- Specify different report type (e.g. `HtmlInline_AzurePipelines_Dark`)
- Include code coverage history

Right now none of these can be implemented because there is no way to pass additional arguments to the report generator.