### PR TITLE
Add option to skip HTML coverage reports

### DIFF
--- a/src/CoveragePublisher.Tests/ArgumentsProcessorTests.cs
+++ b/src/CoveragePublisher.Tests/ArgumentsProcessorTests.cs
@@ -19,6 +19,8 @@ namespace CoveragePublisher.Tests
 
             --sourceDirectory    (Default: ) List of source directories separated by ';'.
 
+            --publishHtmlReport  (Default: true) Publish an HTML coverage report.
+
             --timeout            (Default: 120) Timeout for CoveragePublisher in seconds.
 
             --noTelemetry        (Default: false) Disable telemetry data collection.
@@ -94,6 +96,19 @@ namespace CoveragePublisher.Tests
             {
                 Assert.IsTrue(cliArgs.CoverageFiles.Contains(file));
             }
+        }
+
+        [DataTestMethod]
+        [DataRow(new string[] { @"C:\a.txt", "--reportDirectory", @"C:\report" }, true)]
+        [DataRow(new string[] { @"C:\a.txt", "--reportDirectory", @"C:\report", "--publishHtmlReport", "false" }, false)]
+        public void WillParsePublishHtmlReport(string[] args, bool expected)
+        {
+            var argsProcessor = new ArgumentsProcessor();
+
+            var config = argsProcessor.ProcessCommandLineArgs(args);
+
+            Assert.AreEqual(expected, config.PublishHTMLReport);
+            Assert.AreEqual(expected, config.GenerateHTMLReport);
         }
     }
 }

--- a/src/CoveragePublisher.Tests/Parser/ParserTests.cs
+++ b/src/CoveragePublisher.Tests/Parser/ParserTests.cs
@@ -73,6 +73,23 @@ debug: Parser.GenerateHTMLReport: Copying summary file SampleCoverage/JaCoCo.xml
         }
 
         [TestMethod]
+        public void WillNotGenerateHTMLReportWhenPublicationIsDisabled()
+        {
+            var mockTool = new Mock<ICoverageParserTool>();
+            var config = new PublisherConfiguration()
+            {
+                CoverageFiles = new List<string>() { "SampleCoverage/Cobertura.xml" },
+                ReportDirectory = "report",
+                PublishHTMLReport = false
+            };
+
+            var parser = new TestParser(config, _mockTelemetry.Object);
+            parser.GenerateReport(mockTool.Object);
+
+            mockTool.Verify(x => x.GenerateHTMLReport(), Times.Never);
+        }
+
+        [TestMethod]
         public void WillSafelyLogException()
         {
             var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());

--- a/src/CoveragePublisher/ArgumentsProcessor.cs
+++ b/src/CoveragePublisher/ArgumentsProcessor.cs
@@ -23,6 +23,9 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
             [Option("sourceDirectory", Default = "", HelpText = "List of source directories separated by ';'.")]
             override public string SourceDirectory { get; set; }
 
+            [Option("publishHtmlReport", Default = "true", HelpText = "Publish an HTML coverage report.")]
+            public string PublishHTMLReportValue { get; set; }
+
             [Option("timeout", Default = 120, HelpText = "Timeout for CoveragePublisher in seconds.")]
             public override int TimeoutInSeconds { get; set; }
 
@@ -39,6 +42,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher
             Parser.Default.ParseArguments<Options>(args)
                 .WithParsed<Options>(opts =>
                 {
+                    opts.PublishHTMLReport = bool.Parse(opts.PublishHTMLReportValue);
                     config = opts;
                 });
 

--- a/src/CoveragePublisher/Model/PublisherConfiguration.cs
+++ b/src/CoveragePublisher/Model/PublisherConfiguration.cs
@@ -24,6 +24,11 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Model
         /// Semi-colon separated list of source directories. Required for creating html reports for jacoco.
         /// </summary>
         virtual public string SourceDirectory { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configuration for whether HTML reports should be published.
+        /// </summary>
+        virtual public bool PublishHTMLReport { get; set; } = true;
         
         /// <summary>
         /// Gets the configuration for whether HTML reports should be generated or not.
@@ -31,7 +36,7 @@ namespace Microsoft.Azure.Pipelines.CoveragePublisher.Model
         virtual public bool GenerateHTMLReport {
             get
             {
-                return !string.IsNullOrEmpty(ReportDirectory);
+                return PublishHTMLReport && !string.IsNullOrEmpty(ReportDirectory);
             }
         }
 


### PR DESCRIPTION
## Summary

Add a backward-compatible `--publishHtmlReport` option that defaults to `true`. Passing `--publishHtmlReport false` skips HTML report generation and upload while preserving coverage parsing, aggregate summary publication, and file-level coverage publication.

The option composes with the existing `GenerateHTMLReport` gate, so callers that omit it retain current behavior.

## Motivation

Large Cobertura reports can spend most of the `PublishCodeCoverageResults@2` runtime generating `HtmlInline_AzurePipelines` output. In one 1JS build with roughly 60,842 classes, parsing took about 12 seconds, but each of two identical HTML generation passes took about 64 minutes. The task ran for 2h12m overall.

This complements the duplicate-generation fix in #101: deduplication removes one unnecessary render, while this option lets pipelines that only need Azure Pipelines summary and file-level coverage avoid HTML generation entirely. Related to #72.

After this publisher is released, a follow-up change in `microsoft/azure-pipelines-tasks` can expose a default-true `publishHtmlReport` task input and pass it through to the publisher CLI.

## Tests

- Added argument tests for omitted/default-on and explicit-off behavior.
- Added a parser test verifying that explicit opt-out does not invoke HTML generation.
- `dotnet test CoveragePublisher.Tests/CoveragePublisher.Tests.csproj`: 69 passed.